### PR TITLE
Fix comment block in UploadModal

### DIFF
--- a/src/components/UploadModal.tsx
+++ b/src/components/UploadModal.tsx
@@ -187,10 +187,10 @@ const UploadModal: React.FC<UploadModalProps> = ({
 
 export default UploadModal;
 
-/* 
+/*
 Adicione ao CSS global:
 
-.modal-backdrop { /* ... igual antes ... */ }
-.modal-content { /* ... */ }
-/* etc */
+.modal-backdrop { ... }
+.modal-content { ... }
+// etc
 */


### PR DESCRIPTION
## Summary
- correct comment block at the end of `UploadModal` so TypeScript doesn't parse stray `*/`

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68688c79b278832fa4e91ec7815489d4