### PR TITLE
Fix Vite root config

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,6 @@ Plataforma de Ads
    ```bash
    npm run dev
    ```
+
+O projeto utiliza a pasta `src` como raiz do Vite. Certifique-se de que o arquivo
+`index.html` permanece dentro de `src`.

--- a/src/index.html
+++ b/src/index.html
@@ -7,6 +7,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="/main.tsx"></script>
   </body>
 </html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,5 +2,9 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
+  root: 'src',
   plugins: [react()],
+  build: {
+    outDir: '../dist',
+  },
 });


### PR DESCRIPTION
## Summary
- use `src` as the Vite project root
- load the correct entry file in `index.html`
- note the Vite root in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686c5cac3668832fba31e5e8344f3179