### PR TITLE
Fix object URL cleanup

### DIFF
--- a/src/components/MediaItem.tsx
+++ b/src/components/MediaItem.tsx
@@ -6,8 +6,15 @@ interface Props {
 }
 
 const MediaItem: React.FC<Props> = ({ item }) => {
-  const url = React.useMemo(() => {
-    return URL.createObjectURL(new Blob([item.file]));
+  const [url, setUrl] = React.useState('');
+
+  React.useEffect(() => {
+    const objectUrl = URL.createObjectURL(new Blob([item.file]));
+    setUrl(objectUrl);
+
+    return () => {
+      URL.revokeObjectURL(objectUrl);
+    };
   }, [item.file]);
 
   return (


### PR DESCRIPTION
## Summary
- update `MediaItem` to store created URL in state
- clean up URLs with `URL.revokeObjectURL`

## Testing
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68784a24dfa4832fa7a8f8bd31e55a80