### PR TITLE
Add testing setup with Vitest and React Testing Library

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -18,6 +19,10 @@
     "typescript": "^4.9.3",
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
-    "@vitejs/plugin-react": "^4.0.0"
+    "@vitejs/plugin-react": "^4.0.0",
+    "vitest": "^1.0.0",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/user-event": "^14.4.3",
+    "@testing-library/jest-dom": "^6.1.0"
   }
 }

--- a/src/__tests__/BudgetEditor.test.tsx
+++ b/src/__tests__/BudgetEditor.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import BudgetEditor from '../components/BudgetEditor';
+import { vi } from 'vitest';
+import { fetchBudgetItems, updateBudget } from '../components/mediaQueue';
+
+defineGlobals();
+
+vi.mock('../components/mediaQueue', () => {
+  return {
+    fetchBudgetItems: vi.fn(),
+    updateBudget: vi.fn(),
+  };
+});
+
+function defineGlobals() {}
+
+describe('BudgetEditor', () => {
+  it('allows editing budget and applying changes', async () => {
+    (fetchBudgetItems as any).mockResolvedValue([
+      { id: '1', name: 'Item 1', currentBudget: 10 },
+    ]);
+
+    render(<BudgetEditor />);
+
+    const input = await screen.findByDisplayValue('10');
+    fireEvent.change(input, { target: { value: '20' } });
+
+    const button = screen.getByRole('button', { name: /Aplicar Alterações/i });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(updateBudget).toHaveBeenCalledWith('1', 20);
+    });
+  });
+});

--- a/src/__tests__/UploadQueue.test.tsx
+++ b/src/__tests__/UploadQueue.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import UploadQueue from '../components/UploadQueue';
+import { vi } from 'vitest';
+import { processUploadQueue, db } from '../components/mediaQueue';
+import { liveQuery } from 'dexie';
+
+defineGlobals();
+
+vi.mock('../components/mediaQueue', () => {
+  const mockItems = [
+    {
+      id: 1,
+      name: 'file1',
+      type: 'image',
+      status: 'pending',
+      size: 10,
+      file: new ArrayBuffer(1),
+      createdAt: 0,
+    },
+    {
+      id: 2,
+      name: 'file2',
+      type: 'image',
+      status: 'failed',
+      size: 20,
+      file: new ArrayBuffer(1),
+      createdAt: 0,
+    },
+  ];
+  return {
+    db: {
+      uploadQueue: {
+        toArray: vi.fn(() => mockItems),
+        delete: vi.fn(),
+      },
+    },
+    processUploadQueue: vi.fn(),
+  };
+});
+
+vi.mock('dexie', () => {
+  return {
+    liveQuery: (fn: any) => {
+      return {
+        subscribe({ next }: any) {
+          Promise.resolve(fn()).then(next);
+          return { unsubscribe: vi.fn() };
+        },
+      };
+    },
+  };
+});
+
+function defineGlobals() {
+  // Vitest with jsdom sets these globals automatically when globals: true is enabled
+}
+
+describe('UploadQueue', () => {
+  it('processes queue when publish button is clicked', async () => {
+    render(<UploadQueue />);
+    const button = await screen.findByRole('button', { name: /Publicar Mudanças/i });
+    fireEvent.click(button);
+    expect(processUploadQueue).toHaveBeenCalled();
+  });
+
+  it('retries failed items and cancels pending', async () => {
+    render(<UploadQueue />);
+    const retry = await screen.findByRole('button', { name: /Reenviar/i });
+    fireEvent.click(retry);
+    expect(processUploadQueue).toHaveBeenCalled();
+
+    const cancelButtons = screen.getAllByRole('button', { name: /Cancelar/i });
+    fireEvent.click(cancelButtons[0]);
+    expect(db.uploadQueue.delete).toHaveBeenCalledWith(1);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
@@ -7,4 +7,9 @@ export default defineConfig({
   build: {
     outDir: '../dist',
   },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: '../vitest.setup.ts'
+  }
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/extend-expect';


### PR DESCRIPTION
## Summary
- configure Vitest and React Testing Library for unit tests
- add test script
- include minimal setup file
- create tests for `UploadQueue` and `BudgetEditor`

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878dc9db808832fba3b5948856be2e6