### PR TITLE
Handle failed uploads

### DIFF
--- a/src/__tests__/processUploadQueue.test.ts
+++ b/src/__tests__/processUploadQueue.test.ts
@@ -1,0 +1,47 @@
+import { processUploadQueue, db } from '../components/mediaQueue';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+vi.mock('react-toastify', () => ({
+  toast: { info: vi.fn(), success: vi.fn(), error: vi.fn() }
+}));
+
+const originalFetch = global.fetch;
+
+describe('processUploadQueue', () => {
+  beforeEach(() => {
+    (global as any).fetch = vi.fn().mockResolvedValue({ ok: false });
+  });
+
+  afterEach(() => {
+    (global as any).fetch = originalFetch;
+  });
+
+  it('marks failed uploads as failed', async () => {
+    const pendingItem = {
+      id: 1,
+      file: new ArrayBuffer(1),
+      type: 'image' as const,
+      name: 'img.png',
+      size: 1,
+      status: 'pending' as const,
+      createdAt: 0,
+    };
+
+    const update = vi.fn();
+    const del = vi.fn();
+    const toArray = vi.fn().mockResolvedValue([pendingItem]);
+    const equals = vi.fn(() => ({ toArray }));
+    const where = vi.fn(() => ({ equals }));
+
+    const originalQueue = db.uploadQueue;
+    db.uploadQueue = { where, update, delete: del } as any;
+
+    await processUploadQueue();
+
+    expect(update).toHaveBeenCalledWith(1, { status: 'uploading' });
+    expect(update).toHaveBeenCalledWith(1, { status: 'failed' });
+    expect(del).not.toHaveBeenCalled();
+
+    db.uploadQueue = originalQueue;
+  });
+});

--- a/src/components/mediaQueue.ts
+++ b/src/components/mediaQueue.ts
@@ -6,7 +6,7 @@ import { toast } from 'react-toastify';
 // --- INTERFACES E TIPOS --- //
 
 type MediaType = 'image' | 'video';
-type UploadStatus = 'pending' | 'uploading';
+type UploadStatus = 'pending' | 'uploading' | 'failed';
 
 export interface IUploadQueueItem {
   id?: number;
@@ -103,7 +103,7 @@ export async function processUploadQueue(): Promise<void> {
 
     } catch (err: any) {
       console.error(`Erro no upload de ${name}:`, err);
-      await db.uploadQueue.update(id, { status: 'pending' });
+      await db.uploadQueue.update(id, { status: 'failed' });
       toast.error(`Falha no upload de "${name}", será tentado novamente`);
     }
   }


### PR DESCRIPTION
## Summary
- support `failed` status in `UploadStatus`
- mark queue items as failed if upload throws
- add unit test covering failed status

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68797a6ededc832fa783797387541500