### PR TITLE
Atualiza env vars para Vite

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Plataforma de Ads
    npm install
    ```
 
-2. Copie `.env.local.example` para `.env.local` e informe suas credenciais da API:
+2. Copie `.env.local.example` para `.env.local` e informe suas credenciais da API. O Vite usa seu próprio sistema de variáveis de ambiente, portanto utilize as chaves abaixo:
    ```bash
    cp .env.local.example .env.local
-   # edite o arquivo gerado
+   # edite o arquivo gerado, preenchendo VITE_AD_ACCOUNT_ID e VITE_ACCESS_TOKEN
    ```
 
 3. Inicie o servidor de desenvolvimento:
@@ -21,3 +21,6 @@ Plataforma de Ads
 
 O projeto utiliza a pasta `src` como raiz do Vite. Certifique-se de que o arquivo
 `index.html` permanece dentro de `src`.
+
+As variáveis de ambiente declaradas em `.env.local` ficam disponíveis no código
+através de `import.meta.env`.

--- a/env.local.example
+++ b/env.local.example
@@ -1,2 +1,2 @@
-REACT_APP_AD_ACCOUNT_ID=act_your_account_id
-REACT_APP_ACCESS_TOKEN=your_access_token
+VITE_AD_ACCOUNT_ID=act_your_account_id
+VITE_ACCESS_TOKEN=your_access_token

--- a/src/components/mediaQueue.ts
+++ b/src/components/mediaQueue.ts
@@ -35,12 +35,12 @@ const db = new AppDB();
 
 // --- VARIÁVEIS DE AMBIENTE --- //
 
-const AD_ACCOUNT_ID = process.env.REACT_APP_AD_ACCOUNT_ID!;
-const ACCESS_TOKEN = process.env.REACT_APP_ACCESS_TOKEN!;
+const AD_ACCOUNT_ID = import.meta.env.VITE_AD_ACCOUNT_ID!;
+const ACCESS_TOKEN = import.meta.env.VITE_ACCESS_TOKEN!;
 const META_GRAPH_API_URL = 'https://graph.facebook.com/v23.0';
 
 if (!AD_ACCOUNT_ID || !ACCESS_TOKEN) {
-  console.error('Faltam variáveis de ambiente REACT_APP_AD_ACCOUNT_ID ou REACT_APP_ACCESS_TOKEN');
+  console.error('Faltam variáveis de ambiente VITE_AD_ACCOUNT_ID ou VITE_ACCESS_TOKEN');
 }
 
 // --- FUNÇÕES PRINCIPAIS --- //

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary
- rename environment variables to match Vite conventions
- update mediaQueue.ts to use `import.meta.env`
- document the new variables in README and .env example
- add Vite type declarations

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879823e65bc832f95fe94edc5e49bae