### PR TITLE
Add testing step to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ Plataforma de Ads
    npm run dev
    ```
 
+4. Execute os testes automatizados:
+   ```bash
+   npm run test
+   ```
+
 O projeto utiliza o Vite com `public/index.html` como ponto de entrada.
 Os módulos que interagem com a API da Meta foram movidos para `backend-meta/` e
 são simulados no ambiente do Codex por `src/mocks/handlers.ts`.


### PR DESCRIPTION
## Summary
- document how to run automated tests in README

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a3c5fcaec832f8c40f17681e0d794