### PR TITLE
Add campaign audience and creative components

### DIFF
--- a/src/components/Campaign/CampaignAudience.tsx
+++ b/src/components/Campaign/CampaignAudience.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+interface CampaignAudienceProps {
+  audienceId: string;
+  onChange: (audienceId: string) => void;
+}
+
+const CampaignAudience: React.FC<CampaignAudienceProps> = ({ audienceId, onChange }) => (
+  <div className="p-4 border rounded space-y-4">
+    <h3 className="text-lg font-bold">Público</h3>
+    <div>
+      <label className="block mb-1 font-medium" htmlFor="audienceId">
+        Audience ID
+      </label>
+      <input
+        id="audienceId"
+        type="text"
+        value={audienceId}
+        onChange={(e) => onChange(e.target.value)}
+        className="border rounded px-2 py-1 w-full"
+      />
+    </div>
+  </div>
+);
+
+export default CampaignAudience;

--- a/src/components/Campaign/CampaignCreative.tsx
+++ b/src/components/Campaign/CampaignCreative.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import PageSelector from './PageSelector';
+
+export interface CampaignCreativeValues {
+  files: File[];
+  message: string;
+  link: string;
+  page: string;
+}
+
+interface CampaignCreativeProps extends CampaignCreativeValues {
+  onChange: (values: CampaignCreativeValues) => void;
+}
+
+const CampaignCreative: React.FC<CampaignCreativeProps> = ({
+  files,
+  message,
+  link,
+  page,
+  onChange,
+}) => {
+  const handleChange = (
+    field: keyof CampaignCreativeValues,
+    value: string | File[]
+  ) => {
+    const next: CampaignCreativeValues = { files, message, link, page, [field]: value } as CampaignCreativeValues;
+    onChange(next);
+  };
+
+  const onFilesChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selected = e.target.files ? Array.from(e.target.files) : [];
+    handleChange('files', selected);
+  };
+
+  return (
+    <div className="p-4 border rounded space-y-4">
+      <h3 className="text-lg font-bold">Criativo</h3>
+      <div>
+        <label className="block mb-1 font-medium" htmlFor="files">
+          Mídia
+        </label>
+        <input id="files" type="file" multiple onChange={onFilesChange} />
+        {files.length > 0 && (
+          <p className="text-sm text-gray-600 mt-1">
+            {files.length} arquivo(s) selecionado(s)
+          </p>
+        )}
+      </div>
+      <div>
+        <label className="block mb-1 font-medium" htmlFor="message">
+          Mensagem
+        </label>
+        <textarea
+          id="message"
+          value={message}
+          onChange={(e) => handleChange('message', e.target.value)}
+          className="border rounded px-2 py-1 w-full"
+        />
+      </div>
+      <div>
+        <label className="block mb-1 font-medium" htmlFor="link">
+          Link
+        </label>
+        <input
+          id="link"
+          type="url"
+          value={link}
+          onChange={(e) => handleChange('link', e.target.value)}
+          className="border rounded px-2 py-1 w-full"
+        />
+      </div>
+      <PageSelector
+        selectedPage={page}
+        onChange={(p) => handleChange('page', p)}
+      />
+    </div>
+  );
+};
+
+export default CampaignCreative;

--- a/src/components/Campaign/PageSelector.tsx
+++ b/src/components/Campaign/PageSelector.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+interface PageSelectorProps {
+  selectedPage: string;
+  onChange: (page: string) => void;
+}
+
+const options = [
+  { value: '', label: 'Selecione uma página' },
+  { value: 'page-1', label: 'Página 1' },
+  { value: 'page-2', label: 'Página 2' },
+];
+
+const PageSelector: React.FC<PageSelectorProps> = ({ selectedPage, onChange }) => (
+  <div>
+    <label className="block mb-1 font-medium" htmlFor="page">
+      Página
+    </label>
+    <select
+      id="page"
+      value={selectedPage}
+      onChange={(e) => onChange(e.target.value)}
+      className="border rounded px-2 py-1 w-full"
+    >
+      {options.map((opt) => (
+        <option key={opt.value} value={opt.value}>
+          {opt.label}
+        </option>
+      ))}
+    </select>
+  </div>
+);
+
+export default PageSelector;


### PR DESCRIPTION
## Summary
- add `<CampaignAudience>` for editing the audience id
- add `<CampaignCreative>` to capture creative details and select a page
- include `<PageSelector>` with simple hard-coded options

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a44a686f8832f908a36bcfe78ae2a