### PR TITLE
Add campaign wizard tests

### DIFF
--- a/src/__tests__/CampaignAudience.test.tsx
+++ b/src/__tests__/CampaignAudience.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import CampaignAudience from '../components/Campaign/CampaignAudience';
+import { vi } from 'vitest';
+
+defineGlobals();
+
+vi.mock('../components/mediaQueue', () => ({}));
+
+function defineGlobals() {}
+
+describe('CampaignAudience', () => {
+  it('calls onChange with updated audience id', () => {
+    const handleChange = vi.fn();
+    render(<CampaignAudience audienceId="123" onChange={handleChange} />);
+
+    const input = screen.getByLabelText(/Audience ID/i);
+    fireEvent.change(input, { target: { value: '456' } });
+
+    expect(handleChange).toHaveBeenCalledWith('456');
+  });
+});

--- a/src/__tests__/CampaignBudget.test.tsx
+++ b/src/__tests__/CampaignBudget.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import CampaignBudget, { CampaignBudgetValues } from '../components/Campaign/CampaignBudget';
+import { vi } from 'vitest';
+
+defineGlobals();
+
+vi.mock('../components/mediaQueue', () => ({}));
+
+function defineGlobals() {}
+
+describe('CampaignBudget', () => {
+  it('validates dates and triggers value changes', () => {
+    const handleChange = vi.fn();
+    const initial: CampaignBudgetValues = {
+      budgetType: 'daily',
+      budgetAmount: 10,
+      startDate: '',
+      endDate: '',
+    };
+    render(<CampaignBudget {...initial} onChange={handleChange} />);
+
+    const amountInput = screen.getByLabelText(/Valor do orçamento/i);
+    fireEvent.change(amountInput, { target: { value: '20' } });
+    expect(handleChange).toHaveBeenCalledWith({ ...initial, budgetAmount: 20 });
+
+    const startInput = screen.getByLabelText(/Data de início/i);
+    const endInput = screen.getByLabelText(/Data de término/i);
+
+    fireEvent.change(startInput, { target: { value: '2023-01-02' } });
+    fireEvent.change(endInput, { target: { value: '2023-01-01' } });
+
+    expect(handleChange).toHaveBeenLastCalledWith({
+      ...initial,
+      budgetAmount: 20,
+      startDate: '2023-01-02',
+      endDate: '2023-01-01',
+    });
+    expect(
+      screen.getByText(
+        /A data de término não pode ser anterior à data de início./i
+      )
+    ).toBeInTheDocument();
+
+    fireEvent.change(endInput, { target: { value: '2023-01-03' } });
+    expect(handleChange).toHaveBeenLastCalledWith({
+      ...initial,
+      budgetAmount: 20,
+      startDate: '2023-01-02',
+      endDate: '2023-01-03',
+    });
+    expect(
+      screen.queryByText(
+        /A data de término não pode ser anterior à data de início./i
+      )
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/__tests__/CampaignWizard.test.tsx
+++ b/src/__tests__/CampaignWizard.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import CampaignWizard from '../components/Campaign/CampaignWizard';
+import { vi } from 'vitest';
+import { createCampaign, createAdSet, createAd } from '../components/mediaQueue';
+
+defineGlobals();
+
+vi.mock('../components/mediaQueue', () => ({
+  createCampaign: vi.fn(() => Promise.resolve('camp')),
+  createAdSet: vi.fn(() => Promise.resolve('adset')),
+  createAd: vi.fn(() => Promise.resolve('ad')),
+}));
+
+vi.mock('react-toastify', () => ({
+  toast: { info: vi.fn(), success: vi.fn(), error: vi.fn() },
+}));
+
+function defineGlobals() {}
+
+describe('CampaignWizard', () => {
+  it('steps through wizard and publishes campaign', async () => {
+    render(<CampaignWizard />);
+
+    const audienceInput = screen.getByLabelText(/Audience ID/i);
+    fireEvent.change(audienceInput, { target: { value: 'aud-1' } });
+    fireEvent.click(screen.getByRole('button', { name: /Próximo/i }));
+
+    const amountInput = await screen.findByLabelText(/Valor do orçamento/i);
+    fireEvent.change(amountInput, { target: { value: '50' } });
+    fireEvent.change(screen.getByLabelText(/Data de início/i), {
+      target: { value: '2023-01-01' },
+    });
+    fireEvent.change(screen.getByLabelText(/Data de término/i), {
+      target: { value: '2023-01-02' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Próximo/i }));
+
+    fireEvent.change(await screen.findByLabelText(/Mensagem/i), {
+      target: { value: 'Hello' },
+    });
+    fireEvent.change(screen.getByLabelText(/Página/i), {
+      target: { value: 'page-1' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Finalizar/i }));
+
+    await waitFor(() => {
+      expect(createCampaign).toHaveBeenCalled();
+      expect(createAdSet).toHaveBeenCalled();
+      expect(createAd).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for audience id change
- add tests for budget validation and updates
- test wizard flow through publish step

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a524fb4a4832faac95bdc686d45cc