### PR TITLE
Add objective step to campaign wizard

### DIFF
--- a/src/__tests__/CampaignWizard.test.tsx
+++ b/src/__tests__/CampaignWizard.test.tsx
@@ -21,6 +21,9 @@ describe('CampaignWizard', () => {
   it('steps through wizard and publishes campaign', async () => {
     render(<CampaignWizard />);
 
+    fireEvent.click(screen.getByLabelText(/Conversões/i));
+    fireEvent.click(screen.getByRole('button', { name: /Próximo/i }));
+
     const audienceInput = screen.getByLabelText(/Audience ID/i);
     fireEvent.change(audienceInput, { target: { value: 'aud-1' } });
     fireEvent.click(screen.getByRole('button', { name: /Próximo/i }));
@@ -44,7 +47,7 @@ describe('CampaignWizard', () => {
     fireEvent.click(screen.getByRole('button', { name: /Finalizar/i }));
 
     await waitFor(() => {
-      expect(createCampaign).toHaveBeenCalled();
+      expect(createCampaign).toHaveBeenCalledWith('Nova Campanha', 'CONVERSIONS');
       expect(createAdSet).toHaveBeenCalled();
       expect(createAd).toHaveBeenCalled();
     });

--- a/src/components/Campaign/CampaignObjective.tsx
+++ b/src/components/Campaign/CampaignObjective.tsx
@@ -1,11 +1,35 @@
 import React from 'react';
 
-type Props = {
+interface CampaignObjectiveProps {
   objective: string;
-};
+  onChange: (value: string) => void;
+}
 
-const CampaignObjective: React.FC<Props> = ({ objective }) => {
-  return <span className="font-medium">Objetivo: {objective}</span>;
-};
+const options = [
+  { value: 'LINK_CLICKS', label: 'Cliques no Link' },
+  { value: 'CONVERSIONS', label: 'Conversões' },
+];
+
+const CampaignObjective: React.FC<CampaignObjectiveProps> = ({
+  objective,
+  onChange,
+}) => (
+  <div className="p-4 border rounded space-y-4">
+    <h3 className="text-lg font-bold">Objetivo</h3>
+    <div className="flex space-x-4">
+      {options.map((opt) => (
+        <label key={opt.value} className="flex items-center space-x-1">
+          <input
+            type="radio"
+            value={opt.value}
+            checked={objective === opt.value}
+            onChange={(e) => onChange(e.target.value)}
+          />
+          <span>{opt.label}</span>
+        </label>
+      ))}
+    </div>
+  </div>
+);
 
 export default CampaignObjective;


### PR DESCRIPTION
## Summary
- allow selecting an objective in `CampaignWizard`
- add new `CampaignObjective` component for radio selection
- update wizard logic to use objective and start from this step
- expand CampaignWizard tests for the objective

## Testing
- `npm test` *(fails: `vitest: not found`)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687c3664bd80832fb26ca8e52d3eccb4