### PR TITLE
Clean up unused env variables

### DIFF
--- a/src/components/mediaQueue.ts
+++ b/src/components/mediaQueue.ts
@@ -54,16 +54,6 @@ class AppDB extends Dexie {
 
 const db = new AppDB();
 
-// --- VARIÁVEIS DE AMBIENTE --- //
-
-const AD_ACCOUNT_ID = import.meta.env.VITE_AD_ACCOUNT_ID!;
-const ACCESS_TOKEN = import.meta.env.VITE_ACCESS_TOKEN!;
-const META_GRAPH_API_URL = 'https://graph.facebook.com/v23.0';
-
-if (!AD_ACCOUNT_ID || !ACCESS_TOKEN) {
-  console.error('Faltam variáveis de ambiente VITE_AD_ACCOUNT_ID ou VITE_ACCESS_TOKEN');
-}
-
 // --- FUNÇÕES PRINCIPAIS --- //
 
 /**


### PR DESCRIPTION
## Summary
- remove unused `AD_ACCOUNT_ID`, `ACCESS_TOKEN`, and `META_GRAPH_API_URL` constants from `mediaQueue`

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c38b778e4832f9042231d70314112