### PR TITLE
Fix dev server accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Plataforma de Ads
    ```bash
    npm run dev
    ```
+   O Vite executará em `http://localhost:5173`. Em ambientes remotos como
+   Codespaces, o arquivo `vite.config.ts` já define `server.host` para permitir
+   acesso externo.
 
 4. Execute os testes automatizados:
    ```bash

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,9 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: true
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## Summary
- enable external host access for Vite
- clarify dev server instructions

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c43f3d070832fba281dea63213f5a