### PR TITLE
Fix tests to wait for DOM updates

### DIFF
--- a/src/__tests__/CampaignAudience.test.tsx
+++ b/src/__tests__/CampaignAudience.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import CampaignAudience from '../components/Campaign/CampaignAudience';
 import { vi } from 'vitest';
 
@@ -9,13 +9,15 @@ vi.mock('../components/mediaQueue', () => ({}));
 function defineGlobals() {}
 
 describe('CampaignAudience', () => {
-  it('calls onChange with updated audience id', () => {
+  it('calls onChange with updated audience id', async () => {
     const handleChange = vi.fn();
     render(<CampaignAudience audienceId="123" onChange={handleChange} />);
 
     const input = screen.getByLabelText(/Audience ID/i);
     fireEvent.change(input, { target: { value: '456' } });
 
-    expect(handleChange).toHaveBeenCalledWith('456');
+    await waitFor(() => {
+      expect(handleChange).toHaveBeenCalledWith('456');
+    });
   });
 });

--- a/src/__tests__/CampaignBudget.test.tsx
+++ b/src/__tests__/CampaignBudget.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import CampaignBudget, { CampaignBudgetValues } from '../components/Campaign/CampaignBudget';
 import { vi } from 'vitest';
 
@@ -9,7 +9,7 @@ vi.mock('../components/mediaQueue', () => ({}));
 function defineGlobals() {}
 
 describe('CampaignBudget', () => {
-  it('validates dates and triggers value changes', () => {
+  it('validates dates and triggers value changes', async () => {
     const handleChange = vi.fn();
     const initial: CampaignBudgetValues = {
       budgetType: 'daily',
@@ -21,7 +21,9 @@ describe('CampaignBudget', () => {
 
     const amountInput = screen.getByLabelText(/Valor do orçamento/i);
     fireEvent.change(amountInput, { target: { value: '20' } });
-    expect(handleChange).toHaveBeenCalledWith({ ...initial, budgetAmount: 20 });
+    await waitFor(() => {
+      expect(handleChange).toHaveBeenCalledWith({ ...initial, budgetAmount: 20 });
+    });
 
     const startInput = screen.getByLabelText(/Data de início/i);
     const endInput = screen.getByLabelText(/Data de término/i);
@@ -29,29 +31,37 @@ describe('CampaignBudget', () => {
     fireEvent.change(startInput, { target: { value: '2023-01-02' } });
     fireEvent.change(endInput, { target: { value: '2023-01-01' } });
 
-    expect(handleChange).toHaveBeenLastCalledWith({
-      ...initial,
-      budgetAmount: 20,
-      startDate: '2023-01-02',
-      endDate: '2023-01-01',
+    await waitFor(() => {
+      expect(handleChange).toHaveBeenLastCalledWith({
+        ...initial,
+        budgetAmount: 20,
+        startDate: '2023-01-02',
+        endDate: '2023-01-01',
+      });
     });
-    expect(
-      screen.getByText(
-        /A data de término não pode ser anterior à data de início./i
-      )
-    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          /A data de término não pode ser anterior à data de início./i
+        )
+      ).toBeInTheDocument();
+    });
 
     fireEvent.change(endInput, { target: { value: '2023-01-03' } });
-    expect(handleChange).toHaveBeenLastCalledWith({
-      ...initial,
-      budgetAmount: 20,
-      startDate: '2023-01-02',
-      endDate: '2023-01-03',
+    await waitFor(() => {
+      expect(handleChange).toHaveBeenLastCalledWith({
+        ...initial,
+        budgetAmount: 20,
+        startDate: '2023-01-02',
+        endDate: '2023-01-03',
+      });
     });
-    expect(
-      screen.queryByText(
-        /A data de término não pode ser anterior à data de início./i
-      )
-    ).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.queryByText(
+          /A data de término não pode ser anterior à data de início./i
+        )
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/__tests__/UploadQueue.test.tsx
+++ b/src/__tests__/UploadQueue.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import UploadQueue from '../components/UploadQueue';
 import { vi } from 'vitest';
 import { processUploadQueue, db } from '../components/mediaQueue';
@@ -60,17 +60,23 @@ describe('UploadQueue', () => {
     render(<UploadQueue />);
     const button = await screen.findByRole('button', { name: /Publicar Mudanças/i });
     fireEvent.click(button);
-    expect(processUploadQueue).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(processUploadQueue).toHaveBeenCalled();
+    });
   });
 
   it('retries failed items and cancels pending', async () => {
     render(<UploadQueue />);
     const retry = await screen.findByRole('button', { name: /Reenviar/i });
     fireEvent.click(retry);
-    expect(processUploadQueue).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(processUploadQueue).toHaveBeenCalled();
+    });
 
     const cancelButtons = screen.getAllByRole('button', { name: /Cancelar/i });
     fireEvent.click(cancelButtons[0]);
-    expect(db.uploadQueue.delete).toHaveBeenCalledWith(1);
+    await waitFor(() => {
+      expect(db.uploadQueue.delete).toHaveBeenCalledWith(1);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- ensure CampaignBudget test waits for DOM updates
- wait for async changes in CampaignAudience test
- wait for UploadQueue side effects before asserting

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d08dc057c832f813a4fc4d8f26e7d