### PR TITLE
Add campaign store

### DIFF
--- a/src/stores/useCampaignStore.ts
+++ b/src/stores/useCampaignStore.ts
@@ -1,0 +1,20 @@
+import { create } from 'zustand';
+
+export interface CampaignBudgetValues {
+  budgetType: 'daily' | 'total';
+  budgetAmount: number;
+  startDate: string;
+  endDate: string;
+}
+
+interface CampaignState {
+  budget: CampaignBudgetValues;
+  setBudget: (b: CampaignBudgetValues) => void;
+}
+
+export const useCampaignStore = create<CampaignState>(set => ({
+  budget: { budgetType: 'daily', budgetAmount: 10, startDate: '', endDate: '' },
+  setBudget: budget => set({ budget })
+}));
+
+export default useCampaignStore;


### PR DESCRIPTION
## Summary
- add zustand store for campaign budget state

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688046a910a8832f9da8b56374b2ef87