### PR TITLE
Switch lifetime budget to total budget

### DIFF
--- a/src/components/Campaign/CampaignBudget.tsx
+++ b/src/components/Campaign/CampaignBudget.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export type BudgetType = 'daily' | 'lifetime';
+export type BudgetType = 'daily' | 'total';
 
 export interface CampaignBudgetValues {
   budgetType: BudgetType;
@@ -55,8 +55,8 @@ const CampaignBudget: React.FC<CampaignBudgetProps> = ({
         <label className="flex items-center space-x-1">
           <input
             type="radio"
-            value="lifetime"
-            checked={budgetType === 'lifetime'}
+            value="total"
+            checked={budgetType === 'total'}
             onChange={(e) => handleChange('budgetType', e.target.value)}
           />
           <span>Vitalício</span>

--- a/src/stores/useCampaignStore.ts
+++ b/src/stores/useCampaignStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 
 export interface CampaignBudgetValues {
-  budgetType: 'daily' | 'lifetime';
+  budgetType: 'daily' | 'total';
   budgetAmount: number;
   startDate: string;
   endDate: string;


### PR DESCRIPTION
## Summary
- rename `lifetime` budget type to `total`
- update store typings for `BudgetType`

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688049c2b55c832f81f245b8b1e2e45a