### PR TITLE
Reset store in CampaignWizard test

### DIFF
--- a/src/__tests__/CampaignWizard.test.tsx
+++ b/src/__tests__/CampaignWizard.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import CampaignWizard from '../components/Campaign/CampaignWizard';
-import { vi } from 'vitest';
+import { vi, afterEach } from 'vitest';
+import useCampaignStore from '../stores/useCampaignStore';
 import { createCampaign, createAdSet, createAd } from '../components/mediaQueue';
 
 defineGlobals();
@@ -18,6 +19,11 @@ vi.mock('react-toastify', () => ({
 function defineGlobals() {}
 
 describe('CampaignWizard', () => {
+  afterEach(() => {
+    useCampaignStore.setState({
+      budget: { budgetType: 'daily', budgetAmount: 10, startDate: '', endDate: '' },
+    });
+  });
   it('steps through wizard and publishes campaign', async () => {
     render(<CampaignWizard />);
 


### PR DESCRIPTION
## Summary
- reset `useCampaignStore` after each wizard test

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68804afdd690832fb5e7f3a5a52239cf