### PR TITLE
Refactor campaign store

### DIFF
--- a/src/__tests__/CampaignWizard.test.tsx
+++ b/src/__tests__/CampaignWizard.test.tsx
@@ -21,7 +21,10 @@ function defineGlobals() {}
 describe('CampaignWizard', () => {
   afterEach(() => {
     useCampaignStore.setState({
-      budget: { budgetType: 'daily', budgetAmount: 10, startDate: '', endDate: '' },
+      budgetAmount: 10,
+      budgetType: 'daily',
+      startDate: '',
+      endDate: '',
     });
   });
   it('steps through wizard and publishes campaign', async () => {

--- a/src/components/Campaign/CampaignWizard.tsx
+++ b/src/components/Campaign/CampaignWizard.tsx
@@ -5,7 +5,7 @@ import CampaignCreative, { CampaignCreativeValues } from './CampaignCreative';
 import CampaignObjective from './CampaignObjective';
 import { createCampaign, createAdSet, createAd } from '../mediaQueue';
 import { toast } from 'react-toastify';
-import useCampaignStore, { initialBudget } from '../../stores/useCampaignStore';
+import useCampaignStore, { CampaignBudgetValues } from '../../stores/useCampaignStore';
 
 interface WizardData {
   objective: string;
@@ -26,7 +26,18 @@ const CampaignWizard: React.FC = () => {
   const [step, setStep] = useState<Step>('objective');
   const [data, setData] = useState<WizardData>(initialData);
   const stepIndex = steps.indexOf(step);
-  const { budget, setBudget } = useCampaignStore();
+  const {
+    budgetAmount,
+    budgetType,
+    startDate,
+    endDate,
+    setBudgetAmount,
+    setBudgetType,
+    setStartDate,
+    setEndDate,
+    reset,
+  } = useCampaignStore();
+  const budget = { budgetAmount, budgetType, startDate, endDate };
 
   const handleObjectiveChange = useCallback((objective: string) => {
     setData(prev => ({ ...prev, objective }));
@@ -40,6 +51,16 @@ const CampaignWizard: React.FC = () => {
   const handleCreativeChange = useCallback((creative: CampaignCreativeValues) => {
     setData(prev => ({ ...prev, creative }));
   }, []);
+
+  const handleBudgetChange = useCallback(
+    (values: CampaignBudgetValues) => {
+      setBudgetAmount(values.budgetAmount);
+      setBudgetType(values.budgetType);
+      setStartDate(values.startDate);
+      setEndDate(values.endDate);
+    },
+    [setBudgetAmount, setBudgetType, setStartDate, setEndDate]
+  );
 
   const handleNext = useCallback(() => {
     if (stepIndex < steps.length - 1) {
@@ -64,13 +85,13 @@ const CampaignWizard: React.FC = () => {
       await createAd(adSetId, data.creative.message, data.creative.files);
       toast.success('Campanha publicada com sucesso');
       setData(initialData);
-      setBudget(initialBudget);
+      reset();
       setStep('objective');
     } catch (err) {
       console.error(err);
       toast.error('Falha ao publicar campanha');
     }
-  }, [budget, data, setBudget]);
+  }, [budgetAmount, budgetType, startDate, endDate, data, reset]);
 
   return (
     <div className="p-4 border rounded space-y-4">
@@ -87,7 +108,9 @@ const CampaignWizard: React.FC = () => {
           onChange={handleAudienceChange}
         />
       )}
-      {step === 'budget' && <CampaignBudget {...budget} onChange={setBudget} />}
+      {step === 'budget' && (
+        <CampaignBudget {...budget} onChange={handleBudgetChange} />
+      )}
       {step === 'creative' && (
         <CampaignCreative
           files={data.creative.files}

--- a/src/stores/useCampaignStore.ts
+++ b/src/stores/useCampaignStore.ts
@@ -14,14 +14,21 @@ export const initialBudget: CampaignBudgetValues = {
   endDate: '',
 };
 
-interface CampaignState {
-  budget: CampaignBudgetValues;
-  setBudget: (b: CampaignBudgetValues) => void;
+interface CampaignState extends CampaignBudgetValues {
+  setBudgetAmount: (budgetAmount: number) => void;
+  setBudgetType: (budgetType: 'daily' | 'total') => void;
+  setStartDate: (startDate: string) => void;
+  setEndDate: (endDate: string) => void;
+  reset: () => void;
 }
 
 export const useCampaignStore = create<CampaignState>(set => ({
-  budget: initialBudget,
-  setBudget: budget => set({ budget }),
+  ...initialBudget,
+  setBudgetAmount: budgetAmount => set({ budgetAmount }),
+  setBudgetType: budgetType => set({ budgetType }),
+  setStartDate: startDate => set({ startDate }),
+  setEndDate: endDate => set({ endDate }),
+  reset: () => set({ ...initialBudget }),
 }));
 
 export default useCampaignStore;


### PR DESCRIPTION
## Summary
- convert campaign store to a field-based Zustand store
- adapt `CampaignWizard` to new store API
- update related unit test

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68804e4f46a0832fb4c231984e5af36f