### PR TITLE
Refactor campaign wizard to use selectors

### DIFF
--- a/src/stores/useCampaignStore.ts
+++ b/src/stores/useCampaignStore.ts
@@ -31,4 +31,16 @@ export const useCampaignStore = create<CampaignState>(set => ({
   reset: () => set({ ...initialBudget }),
 }));
 
+export const selectBudgetAmount = (state: CampaignState) => state.budgetAmount;
+export const selectBudgetType = (state: CampaignState) => state.budgetType;
+export const selectStartDate = (state: CampaignState) => state.startDate;
+export const selectEndDate = (state: CampaignState) => state.endDate;
+
+export const selectSetBudgetAmount = (state: CampaignState) =>
+  state.setBudgetAmount;
+export const selectSetBudgetType = (state: CampaignState) => state.setBudgetType;
+export const selectSetStartDate = (state: CampaignState) => state.setStartDate;
+export const selectSetEndDate = (state: CampaignState) => state.setEndDate;
+export const selectReset = (state: CampaignState) => state.reset;
+
 export default useCampaignStore;


### PR DESCRIPTION
## Summary
- add selectors to campaign store
- refactor CampaignWizard to use the selector hooks
- reset campaign store via `getState` on publish

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68804f77ed60832fac59b9383b4f3d60