### PR TITLE
Fix campaign budget reset

### DIFF
--- a/src/stores/useCampaignStore.ts
+++ b/src/stores/useCampaignStore.ts
@@ -9,7 +9,7 @@ export interface CampaignBudgetValues {
 
 export const initialBudget: CampaignBudgetValues = {
   budgetType: 'daily',
-  budgetAmount: 10,
+  budgetAmount: 0,
   startDate: '',
   endDate: '',
 };
@@ -28,7 +28,10 @@ export const useCampaignStore = create<CampaignState>(set => ({
   setBudgetType: budgetType => set({ budgetType }),
   setStartDate: startDate => set({ startDate }),
   setEndDate: endDate => set({ endDate }),
-  reset: () => set({ ...initialBudget }),
+  reset: () => set({
+    ...initialBudget,
+    budgetAmount: 0,
+  }),
 }));
 
 export const selectBudgetAmount = (state: CampaignState) => state.budgetAmount;


### PR DESCRIPTION
## Summary
- adjust initial budget amount for campaign store
- ensure reset sets amount back to zero

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880d01d2318832f8f77ab35e9d22a12