### PR TITLE
Refactor budget types

### DIFF
--- a/src/__tests__/CampaignBudget.test.tsx
+++ b/src/__tests__/CampaignBudget.test.tsx
@@ -1,7 +1,8 @@
 // src/__tests__/CampaignBudget.test.tsx
 import { render, screen, fireEvent } from '@testing-library/react';
 import { act } from 'react';
-import CampaignBudget, { CampaignBudgetValues } from '../components/Campaign/CampaignBudget';
+import CampaignBudget from '../components/Campaign/CampaignBudget';
+import { CampaignBudgetValues } from '../stores/useCampaignStore';
 import { vi, describe, it, expect } from 'vitest';
 
 describe('CampaignBudget', () => {

--- a/src/components/Campaign/CampaignBudget.tsx
+++ b/src/components/Campaign/CampaignBudget.tsx
@@ -1,13 +1,5 @@
 import React from 'react';
-
-export type BudgetType = 'daily' | 'total';
-
-export interface CampaignBudgetValues {
-  budgetType: BudgetType;
-  budgetAmount: number;
-  startDate: string;
-  endDate: string;
-}
+import { CampaignBudgetValues, BudgetType } from '../../stores/useCampaignStore';
 
 interface CampaignBudgetProps extends CampaignBudgetValues {
   onChange: (values: CampaignBudgetValues) => void;

--- a/src/stores/useCampaignStore.ts
+++ b/src/stores/useCampaignStore.ts
@@ -1,7 +1,9 @@
 import { create } from 'zustand';
 
+export type BudgetType = 'daily' | 'total';
+
 export interface CampaignBudgetValues {
-  budgetType: 'daily' | 'total';
+  budgetType: BudgetType;
   budgetAmount: number;
   startDate: string;
   endDate: string;
@@ -16,7 +18,7 @@ export const initialBudget: CampaignBudgetValues = {
 
 interface CampaignState extends CampaignBudgetValues {
   setBudgetAmount: (budgetAmount: number) => void;
-  setBudgetType: (budgetType: 'daily' | 'total') => void;
+  setBudgetType: (budgetType: BudgetType) => void;
   setStartDate: (startDate: string) => void;
   setEndDate: (endDate: string) => void;
   reset: () => void;


### PR DESCRIPTION
## Summary
- centralize `BudgetType` definition inside the store
- re-use store types in `CampaignBudget` component
- update related unit test

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880d50e5c64832faa0d39c758e82894