### PR TITLE
Fix index path in README and Tailwind config

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Plataforma de Ads
    npm run build
    ```
 
-O projeto utiliza o Vite com `public/index.html` como ponto de entrada.
+O projeto utiliza o Vite com `index.html` na raiz do repositório como ponto de entrada.
 Os módulos que interagem com a API da Meta foram movidos para `backend-meta/` e
 são simulados no ambiente do Codex por `src/mocks/handlers.ts`.
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
-    "./public/index.html",
+    "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}"
   ],
   theme: {


### PR DESCRIPTION
## Summary
- update README to point to `index.html` at project root
- update Tailwind config content path for `index.html`

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6880e3f5a50c832fbf33d64db1fc6751