### PR TITLE
Add module type for ES modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "mvp-ads",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",


### PR DESCRIPTION
## Summary
- mark the project as an ES module

## Testing
- `npx vitest run --reporter=dot`
- `npm run build`
- `npm run dev` *(started then stopped)*

------
https://chatgpt.com/codex/tasks/task_e_6880e5ba82bc832f9faeeb3f095c1485