### PR TITLE
Extend campaign store

### DIFF
--- a/src/stores/useCampaignStore.ts
+++ b/src/stores/useCampaignStore.ts
@@ -2,6 +2,17 @@ import { create } from 'zustand';
 
 export type BudgetType = 'daily' | 'total';
 
+export interface CampaignCreativeValues {
+  files: File[];
+  message: string;
+  link: string;
+  page: string;
+}
+
+export interface CampaignTargeting {
+  [key: string]: unknown;
+}
+
 export interface CampaignBudgetValues {
   budgetType: BudgetType;
   budgetAmount: number;
@@ -16,36 +27,83 @@ export const initialBudget: CampaignBudgetValues = {
   endDate: '',
 };
 
-interface CampaignState extends CampaignBudgetValues {
+export interface CampaignValues extends CampaignBudgetValues {
+  objective: string;
+  audienceId: string;
+  creative: CampaignCreativeValues;
+  targeting: CampaignTargeting | null;
+  placements: string[];
+  media: File[];
+}
+
+export const initialCampaign: CampaignValues = {
+  ...initialBudget,
+  objective: '',
+  audienceId: '',
+  creative: { files: [], message: '', link: '', page: '' },
+  targeting: null,
+  placements: [],
+  media: [],
+};
+
+interface CampaignState extends CampaignValues {
   setBudgetAmount: (budgetAmount: number) => void;
   setBudgetType: (budgetType: BudgetType) => void;
   setStartDate: (startDate: string) => void;
   setEndDate: (endDate: string) => void;
+  setObjective: (objective: string) => void;
+  setAudienceId: (audienceId: string) => void;
+  setCreative: (creative: CampaignCreativeValues) => void;
+  setTargeting: (targeting: CampaignTargeting | null) => void;
+  setPlacements: (placements: string[]) => void;
+  setMedia: (media: File[]) => void;
   reset: () => void;
+  resetCampaign: () => void;
 }
 
 export const useCampaignStore = create<CampaignState>(set => ({
-  ...initialBudget,
+  ...initialCampaign,
   setBudgetAmount: budgetAmount => set({ budgetAmount }),
   setBudgetType: budgetType => set({ budgetType }),
   setStartDate: startDate => set({ startDate }),
   setEndDate: endDate => set({ endDate }),
-  reset: () => set({
-    ...initialBudget,
-    budgetAmount: 0,
-  }),
+  setObjective: objective => set({ objective }),
+  setAudienceId: audienceId => set({ audienceId }),
+  setCreative: creative => set({ creative }),
+  setTargeting: targeting => set({ targeting }),
+  setPlacements: placements => set({ placements }),
+  setMedia: media => set({ media }),
+  reset: () =>
+    set({
+      ...initialBudget,
+      budgetAmount: 0,
+    }),
+  resetCampaign: () => set(initialCampaign),
 }));
 
 export const selectBudgetAmount = (state: CampaignState) => state.budgetAmount;
 export const selectBudgetType = (state: CampaignState) => state.budgetType;
 export const selectStartDate = (state: CampaignState) => state.startDate;
 export const selectEndDate = (state: CampaignState) => state.endDate;
+export const selectObjective = (state: CampaignState) => state.objective;
+export const selectAudienceId = (state: CampaignState) => state.audienceId;
+export const selectCreative = (state: CampaignState) => state.creative;
+export const selectTargeting = (state: CampaignState) => state.targeting;
+export const selectPlacements = (state: CampaignState) => state.placements;
+export const selectMedia = (state: CampaignState) => state.media;
 
 export const selectSetBudgetAmount = (state: CampaignState) =>
   state.setBudgetAmount;
 export const selectSetBudgetType = (state: CampaignState) => state.setBudgetType;
 export const selectSetStartDate = (state: CampaignState) => state.setStartDate;
 export const selectSetEndDate = (state: CampaignState) => state.setEndDate;
+export const selectSetObjective = (state: CampaignState) => state.setObjective;
+export const selectSetAudienceId = (state: CampaignState) => state.setAudienceId;
+export const selectSetCreative = (state: CampaignState) => state.setCreative;
+export const selectSetTargeting = (state: CampaignState) => state.setTargeting;
+export const selectSetPlacements = (state: CampaignState) => state.setPlacements;
+export const selectSetMedia = (state: CampaignState) => state.setMedia;
 export const selectReset = (state: CampaignState) => state.reset;
+export const selectResetCampaign = (state: CampaignState) => state.resetCampaign;
 
 export default useCampaignStore;


### PR DESCRIPTION
## Summary
- expand campaign store with new fields including objective, audienceId, creative, targeting, placements and media
- add setters for the new fields
- implement `resetCampaign` to clear all fields while preserving existing budget reset
- expose selectors for new values and setters

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6880f1628a78832f8a4b58071f7cb52b