### PR TITLE
Add persist middleware to campaign store

### DIFF
--- a/src/__tests__/CampaignStore.persist.test.ts
+++ b/src/__tests__/CampaignStore.persist.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.resetModules();
+});
+
+describe('useCampaignStore persistence', () => {
+  it('restores state from localStorage on reload', async () => {
+    const { default: useCampaignStore } = await import('../stores/useCampaignStore');
+    useCampaignStore.getState().setStep('budget');
+
+    const stored = localStorage.getItem('campaign-store');
+    expect(stored).not.toBeNull();
+
+    vi.resetModules();
+    const { default: useCampaignStoreReloaded } = await import('../stores/useCampaignStore');
+    expect(useCampaignStoreReloaded.getState().step).toBe('budget');
+  });
+
+  it('resetCampaign clears memory and storage', async () => {
+    const { default: useCampaignStore } = await import('../stores/useCampaignStore');
+    useCampaignStore.getState().setStep('creative');
+    useCampaignStore.getState().resetCampaign();
+    expect(useCampaignStore.getState().step).toBe('objective');
+    expect(localStorage.getItem('campaign-store')).toBeNull();
+  });
+});

--- a/src/stores/useCampaignStore.ts
+++ b/src/stores/useCampaignStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
 
 export const wizardSteps = ['objective', 'audience', 'budget', 'creative'] as const;
 export type WizardStep = typeof wizardSteps[number];
@@ -68,27 +69,38 @@ export interface CampaignState extends CampaignValues {
   resetCampaign: () => void;
 }
 
-export const useCampaignStore = create<CampaignState>(set => ({
-  ...initialCampaign,
-  step: initialStep,
-  setBudgetAmount: budgetAmount => set({ budgetAmount }),
-  setBudgetType: budgetType => set({ budgetType }),
-  setStartDate: startDate => set({ startDate }),
-  setEndDate: endDate => set({ endDate }),
-  setObjective: objective => set({ objective }),
-  setAudienceId: audienceId => set({ audienceId }),
-  setCreative: creative => set({ creative }),
-  setTargeting: targeting => set({ targeting }),
-  setPlacements: placements => set({ placements }),
-  setMedia: media => set({ media }),
-  setStep: step => set({ step }),
-  reset: () =>
-    set({
-      ...initialBudget,
-      budgetAmount: 0,
+export const useCampaignStore = create<CampaignState>()(
+  persist(
+    set => ({
+      ...initialCampaign,
+      step: initialStep,
+      setBudgetAmount: budgetAmount => set({ budgetAmount }),
+      setBudgetType: budgetType => set({ budgetType }),
+      setStartDate: startDate => set({ startDate }),
+      setEndDate: endDate => set({ endDate }),
+      setObjective: objective => set({ objective }),
+      setAudienceId: audienceId => set({ audienceId }),
+      setCreative: creative => set({ creative }),
+      setTargeting: targeting => set({ targeting }),
+      setPlacements: placements => set({ placements }),
+      setMedia: media => set({ media }),
+      setStep: step => set({ step }),
+      reset: () =>
+        set({
+          ...initialBudget,
+          budgetAmount: 0,
+        }),
+      resetCampaign: () => {
+        set({ ...initialCampaign, step: initialStep });
+        localStorage.removeItem('campaign-store');
+      },
     }),
-  resetCampaign: () => set({ ...initialCampaign, step: initialStep }),
-}));
+    {
+      name: 'campaign-store',
+      storage: createJSONStorage(() => localStorage),
+    }
+  )
+);
 
 export const selectBudgetAmount = (state: CampaignState) => state.budgetAmount;
 export const selectBudgetType = (state: CampaignState) => state.budgetType;


### PR DESCRIPTION
## Summary
- persist `useCampaignStore` with `localStorage`
- clear storage on `resetCampaign`
- test persistence between reloads and clearing state

## Testing
- `npx vitest run --silent`

------
https://chatgpt.com/codex/tasks/task_e_6880f5d91a88832f960016c310d8fac7