### PR TITLE
Add campaign summary step

### DIFF
--- a/src/__tests__/CampaignWizard.test.tsx
+++ b/src/__tests__/CampaignWizard.test.tsx
@@ -48,6 +48,9 @@ describe('CampaignWizard', () => {
     fireEvent.change(screen.getByLabelText(/Página/i), {
       target: { value: 'page-1' },
     });
+    fireEvent.click(screen.getByRole('button', { name: /Próximo/i }));
+
+    expect(await screen.findByText(/Resumo/i)).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /Finalizar/i }));
 
     await waitFor(() => {

--- a/src/components/Campaign/CampaignSummary.tsx
+++ b/src/components/Campaign/CampaignSummary.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { CampaignValues } from '../../stores/useCampaignStore';
+
+interface CampaignSummaryProps extends CampaignValues {}
+
+const CampaignSummary: React.FC<CampaignSummaryProps> = ({
+  objective,
+  audienceId,
+  budgetType,
+  budgetAmount,
+  startDate,
+  endDate,
+  creative,
+  targeting,
+  placements,
+  media,
+}) => {
+  const formatDate = (d: string) => (d ? new Date(d).toLocaleDateString() : '');
+
+  return (
+    <div className="p-4 border rounded space-y-4">
+      <h3 className="text-lg font-bold">Resumo</h3>
+      <div>
+        <strong>Objetivo:</strong> {objective || '-'}
+      </div>
+      <div>
+        <strong>Público:</strong> {audienceId || '-'}
+      </div>
+      <div>
+        <strong>Orçamento:</strong> {budgetType} - R${budgetAmount}
+      </div>
+      <div>
+        <strong>Data de início:</strong> {formatDate(startDate)}
+      </div>
+      <div>
+        <strong>Data de término:</strong> {formatDate(endDate)}
+      </div>
+      <div>
+        <strong>Criativo:</strong>
+        <div className="ml-2">
+          <div>
+            <strong>Mensagem:</strong> {creative.message || '-'}
+          </div>
+          <div>
+            <strong>Link:</strong> {creative.link || '-'}
+          </div>
+          <div>
+            <strong>Página:</strong> {creative.page || '-'}
+          </div>
+          {creative.files.length > 0 && (
+            <ul className="list-disc list-inside">
+              {creative.files.map((f) => (
+                <li key={f.name}>{f.name}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+      {targeting && (
+        <div>
+          <strong>Targeting:</strong>{' '}
+          <pre className="whitespace-pre-wrap break-all">
+            {JSON.stringify(targeting, null, 2)}
+          </pre>
+        </div>
+      )}
+      {placements.length > 0 && (
+        <div>
+          <strong>Placements:</strong> {placements.join(', ')}
+        </div>
+      )}
+      {media.length > 0 && (
+        <div>
+          <strong>Media:</strong> {media.length} arquivo(s)
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CampaignSummary;

--- a/src/components/Campaign/CampaignWizard.tsx
+++ b/src/components/Campaign/CampaignWizard.tsx
@@ -2,6 +2,7 @@ import React, { useCallback } from 'react';
 import CampaignAudience from './CampaignAudience';
 import CampaignBudget from './CampaignBudget';
 import CampaignCreative, { CampaignCreativeValues } from './CampaignCreative';
+import CampaignSummary from './CampaignSummary';
 import CampaignObjective from './CampaignObjective';
 import { createCampaign, createAdSet, createAd } from '../mediaQueue';
 import { toast } from 'react-toastify';
@@ -21,6 +22,9 @@ import useCampaignStore, {
   selectObjective,
   selectAudienceId,
   selectCreative,
+  selectTargeting,
+  selectPlacements,
+  selectMedia,
   selectSetObjective,
   selectSetAudienceId,
   selectSetCreative,
@@ -38,6 +42,9 @@ const CampaignWizard: React.FC = () => {
   const objective = useCampaignStore(selectObjective);
   const audienceId = useCampaignStore(selectAudienceId);
   const creative = useCampaignStore(selectCreative);
+  const targeting = useCampaignStore(selectTargeting);
+  const placements = useCampaignStore(selectPlacements);
+  const media = useCampaignStore(selectMedia);
   const setBudgetAmount = useCampaignStore(selectSetBudgetAmount);
   const setBudgetType = useCampaignStore(selectSetBudgetType);
   const setStartDate = useCampaignStore(selectSetStartDate);
@@ -133,6 +140,20 @@ const CampaignWizard: React.FC = () => {
           link={creative.link}
           page={creative.page}
           onChange={handleCreativeChange}
+        />
+      )}
+      {step === 'summary' && (
+        <CampaignSummary
+          objective={objective}
+          audienceId={audienceId}
+          budgetType={budgetType}
+          budgetAmount={budgetAmount}
+          startDate={startDate}
+          endDate={endDate}
+          creative={creative}
+          targeting={targeting}
+          placements={placements}
+          media={media}
         />
       )}
       <div className="flex space-x-2">

--- a/src/stores/useCampaignStore.ts
+++ b/src/stores/useCampaignStore.ts
@@ -1,7 +1,13 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 
-export const wizardSteps = ['objective', 'audience', 'budget', 'creative'] as const;
+export const wizardSteps = [
+  'objective',
+  'audience',
+  'budget',
+  'creative',
+  'summary',
+] as const;
 export type WizardStep = typeof wizardSteps[number];
 
 export type BudgetType = 'daily' | 'total';


### PR DESCRIPTION
## Summary
- show campaign summary information in a new `CampaignSummary` component
- include the new step in the campaign wizard flow
- update wizard steps in the store
- adjust tests for the additional step

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6880f794b230832fac989ab24610f9d5