### PR TITLE
Integrate step navigation with Zustand store

### DIFF
--- a/src/components/Campaign/CampaignWizard.tsx
+++ b/src/components/Campaign/CampaignWizard.tsx
@@ -14,7 +14,6 @@ import useCampaignStore, {
   selectStartDate,
   selectEndDate,
   selectStep,
-  selectSetStep,
   selectSetBudgetAmount,
   selectSetBudgetType,
   selectSetStartDate,
@@ -29,11 +28,12 @@ import useCampaignStore, {
   selectSetAudienceId,
   selectSetCreative,
   selectResetCampaign,
+  selectNextStep,
+  selectPreviousStep,
 } from '../../stores/useCampaignStore';
 
 const CampaignWizard: React.FC = () => {
   const step = useCampaignStore(selectStep);
-  const setStep = useCampaignStore(selectSetStep);
   const stepIndex = wizardSteps.indexOf(step);
   const budgetAmount = useCampaignStore(selectBudgetAmount);
   const budgetType = useCampaignStore(selectBudgetType);
@@ -53,6 +53,8 @@ const CampaignWizard: React.FC = () => {
   const setAudienceId = useCampaignStore(selectSetAudienceId);
   const setCreative = useCampaignStore(selectSetCreative);
   const resetCampaign = useCampaignStore(selectResetCampaign);
+  const nextStep = useCampaignStore(selectNextStep);
+  const previousStep = useCampaignStore(selectPreviousStep);
 
   const handleObjectiveChange = useCallback(
     (value: string) => {
@@ -87,16 +89,12 @@ const CampaignWizard: React.FC = () => {
   );
 
   const handleNext = useCallback(() => {
-    if (stepIndex < wizardSteps.length - 1) {
-      setStep(wizardSteps[stepIndex + 1]);
-    }
-  }, [stepIndex, setStep]);
+    nextStep();
+  }, [nextStep]);
 
   const handleBack = useCallback(() => {
-    if (stepIndex > 0) {
-      setStep(wizardSteps[stepIndex - 1]);
-    }
-  }, [stepIndex, setStep]);
+    previousStep();
+  }, [previousStep]);
 
   const handleFinish = useCallback(async () => {
     const campaign = {

--- a/src/stores/useCampaignStore.ts
+++ b/src/stores/useCampaignStore.ts
@@ -61,6 +61,8 @@ export const initialCampaign: CampaignValues = {
 export interface CampaignState extends CampaignValues {
   step: WizardStep;
   setStep: (step: WizardStep) => void;
+  nextStep: () => void;
+  previousStep: () => void;
   setBudgetAmount: (budgetAmount: number) => void;
   setBudgetType: (budgetType: BudgetType) => void;
   setStartDate: (startDate: string) => void;
@@ -91,6 +93,18 @@ export const useCampaignStore = create<CampaignState>()(
       setPlacements: placements => set({ placements }),
       setMedia: media => set({ media }),
       setStep: step => set({ step }),
+      nextStep: () =>
+        set(state => {
+          const idx = wizardSteps.indexOf(state.step);
+          return idx < wizardSteps.length - 1
+            ? { step: wizardSteps[idx + 1] }
+            : {};
+        }),
+      previousStep: () =>
+        set(state => {
+          const idx = wizardSteps.indexOf(state.step);
+          return idx > 0 ? { step: wizardSteps[idx - 1] } : {};
+        }),
       reset: () =>
         set({
           ...initialBudget,
@@ -119,6 +133,8 @@ export const selectTargeting = (state: CampaignState) => state.targeting;
 export const selectPlacements = (state: CampaignState) => state.placements;
 export const selectMedia = (state: CampaignState) => state.media;
 export const selectStep = (state: CampaignState) => state.step;
+export const selectNextStep = (state: CampaignState) => state.nextStep;
+export const selectPreviousStep = (state: CampaignState) => state.previousStep;
 
 export const selectSetBudgetAmount = (state: CampaignState) =>
   state.setBudgetAmount;


### PR DESCRIPTION
## Summary
- add `nextStep` and `previousStep` helpers in campaign store
- update CampaignWizard to use navigation helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880ffdab8bc832f8259eb79b5508386