### PR TITLE
Add campaign scheduling step

### DIFF
--- a/src/__tests__/CampaignWizard.test.tsx
+++ b/src/__tests__/CampaignWizard.test.tsx
@@ -29,6 +29,13 @@ describe('CampaignWizard', () => {
     fireEvent.change(amountInput, { target: { value: '50' } });
     fireEvent.click(screen.getByRole('button', { name: /Próximo/i }));
 
+    const startInput = await screen.findByLabelText(/Data de início/i);
+    fireEvent.change(startInput, { target: { value: '2023-01-02' } });
+    fireEvent.change(screen.getByLabelText(/Data de término/i), {
+      target: { value: '2023-01-03' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Próximo/i }));
+
     const audienceInput = await screen.findByLabelText(/Audience ID/i);
     fireEvent.change(audienceInput, { target: { value: 'aud-1' } });
     fireEvent.click(screen.getByRole('button', { name: /Próximo/i }));

--- a/src/__tests__/StepScheduling.test.tsx
+++ b/src/__tests__/StepScheduling.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import StepScheduling from '../components/Campaign/steps/StepScheduling';
+import useCampaignStore from '../stores/useCampaignStore';
+import { vi } from 'vitest';
+
+describe('StepScheduling', () => {
+  beforeEach(() => {
+    useCampaignStore.getState().resetCampaign();
+  });
+
+  it('validates dates and updates campaign on next', () => {
+    const goNextSpy = vi.spyOn(useCampaignStore.getState(), 'goNext');
+    const updateSpy = vi.spyOn(useCampaignStore.getState(), 'updateCampaign');
+
+    render(<StepScheduling />);
+
+    const startInput = screen.getByLabelText(/Data de início/i);
+    const endInput = screen.getByLabelText(/Data de término/i);
+
+    fireEvent.change(startInput, { target: { value: '2023-01-02' } });
+    fireEvent.change(endInput, { target: { value: '2023-01-01' } });
+    fireEvent.click(screen.getByRole('button', { name: /Próximo/i }));
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      /A data de término não pode ser anterior à data de início./i
+    );
+    expect(goNextSpy).not.toHaveBeenCalled();
+
+    fireEvent.change(endInput, { target: { value: '2023-01-03' } });
+    fireEvent.click(screen.getByRole('button', { name: /Próximo/i }));
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(updateSpy).toHaveBeenLastCalledWith({
+      startDate: '2023-01-02',
+      endDate: '2023-01-03',
+    });
+    expect(goNextSpy).toHaveBeenCalled();
+  });
+});

--- a/src/components/Campaign/CampaignWizard.tsx
+++ b/src/components/Campaign/CampaignWizard.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import useCampaignStore from '../../stores/useCampaignStore';
 import StepBudget from './steps/StepBudget';
+import StepScheduling from './steps/StepScheduling';
 import StepTargeting from './steps/StepTargeting';
 import StepContent from './steps/StepContent';
 import StepReview from './steps/StepReview';
 
-const steps = [StepBudget, StepTargeting, StepContent, StepReview];
+const steps = [StepBudget, StepScheduling, StepTargeting, StepContent, StepReview];
 
 const CampaignWizard: React.FC = () => {
   const stepIndex = useCampaignStore((s) => s.stepIndex);

--- a/src/components/Campaign/steps/StepScheduling.tsx
+++ b/src/components/Campaign/steps/StepScheduling.tsx
@@ -1,0 +1,67 @@
+import React, { useState } from 'react';
+import useCampaignStore from '../../../stores/useCampaignStore';
+
+const StepScheduling: React.FC = () => {
+  const startDate = useCampaignStore((s) => s.startDate);
+  const endDate = useCampaignStore((s) => s.endDate);
+  const setStartDate = useCampaignStore((s) => s.setStartDate);
+  const setEndDate = useCampaignStore((s) => s.setEndDate);
+  const updateCampaign = useCampaignStore((s) => s.updateCampaign);
+  const goNext = useCampaignStore((s) => s.goNext);
+  const goBack = useCampaignStore((s) => s.goBack);
+  const stepIndex = useCampaignStore((s) => s.stepIndex);
+  const [error, setError] = useState('');
+
+  const handleNext = () => {
+    if (startDate && endDate && endDate < startDate) {
+      setError('A data de término não pode ser anterior à data de início.');
+      return;
+    }
+    updateCampaign({ startDate, endDate });
+    setError('');
+    goNext();
+  };
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-lg font-bold">Agendamento</h2>
+      <input
+        type="date"
+        value={startDate}
+        onChange={(e) => setStartDate(e.target.value)}
+        className="border rounded px-2 py-1"
+        aria-label="Data de início"
+      />
+      <input
+        type="date"
+        value={endDate}
+        onChange={(e) => setEndDate(e.target.value)}
+        className="border rounded px-2 py-1"
+        aria-label="Data de término"
+      />
+      {error && (
+        <p className="text-red-500" role="alert">
+          {error}
+        </p>
+      )}
+      <div className="flex space-x-2">
+        {stepIndex > 0 && (
+          <button
+            onClick={goBack}
+            className="px-4 py-2 rounded bg-gray-500 text-white hover:bg-gray-600"
+          >
+            Voltar
+          </button>
+        )}
+        <button
+          onClick={handleNext}
+          className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700"
+        >
+          Próximo
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default StepScheduling;

--- a/src/stores/useCampaignStore.ts
+++ b/src/stores/useCampaignStore.ts
@@ -3,6 +3,7 @@ import { persist, createJSONStorage } from 'zustand/middleware';
 
 export const wizardSteps = [
   'budget',
+  'scheduling',
   'targeting',
   'content',
   'review',
@@ -75,6 +76,8 @@ export interface CampaignState extends CampaignValues {
   setTargeting: (targeting: CampaignTargeting | null) => void;
   setPlacements: (placements: string[]) => void;
   setMedia: (media: File[]) => void;
+  updateCampaign: (values: Partial<CampaignValues>) => void;
+  setDates: (dates: { startDate: string; endDate: string }) => void;
   reset: () => void;
   resetCampaign: () => void;
 }
@@ -112,6 +115,8 @@ export const useCampaignStore = create<CampaignState>()(
         setTargeting: targeting => set({ targeting }),
         setPlacements: placements => set({ placements }),
         setMedia: media => set({ media }),
+        updateCampaign: values => set({ ...values }),
+        setDates: dates => set({ ...dates }),
         setStep,
         nextStep: next,
         previousStep: previous,
@@ -167,6 +172,8 @@ export const selectSetCreative = (state: CampaignState) => state.setCreative;
 export const selectSetTargeting = (state: CampaignState) => state.setTargeting;
 export const selectSetPlacements = (state: CampaignState) => state.setPlacements;
 export const selectSetMedia = (state: CampaignState) => state.setMedia;
+export const selectUpdateCampaign = (state: CampaignState) => state.updateCampaign;
+export const selectSetDates = (state: CampaignState) => state.setDates;
 export const selectSetStep = (state: CampaignState) => state.setStep;
 export const selectReset = (state: CampaignState) => state.reset;
 export const selectResetCampaign = (state: CampaignState) => state.resetCampaign;


### PR DESCRIPTION
## Summary
- allow campaigns to collect start and end dates via new `StepScheduling`
- update Zustand store to handle scheduling fields and updateCampaign helper
- include scheduling step in the wizard flow
- cover scheduling UI with unit tests and update wizard test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881161a8c40832f91a30b924dc45bc4