### PR TITLE
Add investment step to campaign wizard

### DIFF
--- a/src/__tests__/StepInvestment.test.tsx
+++ b/src/__tests__/StepInvestment.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import StepInvestment from '../steps/StepInvestment';
+import useCampaignStore from '../stores/useCampaignStore';
+import { vi } from 'vitest';
+
+describe('StepInvestment', () => {
+  beforeEach(() => {
+    useCampaignStore.getState().resetCampaign();
+  });
+
+  it('validates amount and updates campaign on next', () => {
+    const goNextSpy = vi.spyOn(useCampaignStore.getState(), 'goNext');
+    const updateSpy = vi.spyOn(useCampaignStore.getState(), 'updateCampaign');
+
+    render(<StepInvestment />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Próximo/i }));
+    expect(screen.getByRole('alert')).toHaveTextContent(/maior que zero/i);
+    expect(goNextSpy).not.toHaveBeenCalled();
+
+    fireEvent.change(screen.getByLabelText(/Valor do orçamento/i), {
+      target: { value: '25' },
+    });
+    fireEvent.click(screen.getByLabelText(/Orçamento total/i));
+    fireEvent.click(screen.getByRole('button', { name: /Próximo/i }));
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(updateSpy).toHaveBeenLastCalledWith({
+      budgetType: 'total',
+      budgetAmount: 25,
+    });
+    expect(goNextSpy).toHaveBeenCalled();
+  });
+});

--- a/src/components/Campaign/CampaignWizard.tsx
+++ b/src/components/Campaign/CampaignWizard.tsx
@@ -1,16 +1,22 @@
 import React from 'react';
 import useCampaignStore from '../../stores/useCampaignStore';
-import StepBudget from './steps/StepBudget';
+import StepInvestment from '../../steps/StepInvestment';
 import StepScheduling from './steps/StepScheduling';
 import StepTargeting from './steps/StepTargeting';
 import StepContent from './steps/StepContent';
 import StepReview from './steps/StepReview';
 
-const steps = [StepBudget, StepScheduling, StepTargeting, StepContent, StepReview];
+const steps = [
+  StepInvestment,
+  StepScheduling,
+  StepTargeting,
+  StepContent,
+  StepReview,
+];
 
 const CampaignWizard: React.FC = () => {
   const stepIndex = useCampaignStore((s) => s.stepIndex);
-  const Current = steps[stepIndex] ?? StepBudget;
+  const Current = steps[stepIndex] ?? StepInvestment;
   return (
     <div className="p-4 border rounded space-y-4">
       <Current />

--- a/src/steps/StepInvestment.tsx
+++ b/src/steps/StepInvestment.tsx
@@ -1,0 +1,87 @@
+import React, { useState } from 'react';
+import useCampaignStore from '../stores/useCampaignStore';
+
+const StepInvestment: React.FC = () => {
+  const budgetType = useCampaignStore((s) => s.budgetType);
+  const budgetAmount = useCampaignStore((s) => s.budgetAmount);
+  const setBudgetType = useCampaignStore((s) => s.setBudgetType);
+  const setBudgetAmount = useCampaignStore((s) => s.setBudgetAmount);
+  const updateCampaign = useCampaignStore((s) => s.updateCampaign);
+  const goNext = useCampaignStore((s) => s.goNext);
+  const goBack = useCampaignStore((s) => s.goBack);
+  const stepIndex = useCampaignStore((s) => s.stepIndex);
+  const [error, setError] = useState('');
+
+  const handleNext = () => {
+    if (budgetAmount < 1) {
+      setError('O orçamento deve ser maior que zero.');
+      return;
+    }
+    updateCampaign({ budgetType, budgetAmount });
+    setError('');
+    goNext();
+  };
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-lg font-bold">Orçamento</h2>
+      <div className="flex space-x-4">
+        <label className="flex items-center space-x-1">
+          <input
+            type="radio"
+            value="daily"
+            checked={budgetType === 'daily'}
+            onChange={(e) => setBudgetType(e.target.value as 'daily')}
+          />
+          <span>Orçamento diário</span>
+        </label>
+        <label className="flex items-center space-x-1">
+          <input
+            type="radio"
+            value="total"
+            checked={budgetType === 'total'}
+            onChange={(e) => setBudgetType(e.target.value as 'total')}
+          />
+          <span>Orçamento total</span>
+        </label>
+      </div>
+      <div>
+        <label className="block mb-1 font-medium" htmlFor="budgetAmount">
+          Valor do orçamento
+        </label>
+        <input
+          id="budgetAmount"
+          type="number"
+          min={1}
+          value={budgetAmount}
+          onChange={(e) => setBudgetAmount(Number(e.target.value))}
+          className="border rounded px-2 py-1"
+          aria-label="Valor do orçamento"
+        />
+      </div>
+      {error && (
+        <p className="text-red-500" role="alert">
+          {error}
+        </p>
+      )}
+      <div className="flex space-x-2">
+        {stepIndex > 0 && (
+          <button
+            onClick={goBack}
+            className="px-4 py-2 rounded bg-gray-500 text-white hover:bg-gray-600"
+          >
+            Voltar
+          </button>
+        )}
+        <button
+          onClick={handleNext}
+          className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700"
+        >
+          Próximo
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default StepInvestment;


### PR DESCRIPTION
## Summary
- create `StepInvestment` with radio options and validation
- include `StepInvestment` in `CampaignWizard`
- add tests for the new step

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68824559d0b8832f8159fa9696c534df