### PR TITLE
Add StepPreview final wizard step

### DIFF
--- a/src/__tests__/CampaignWizard.test.tsx
+++ b/src/__tests__/CampaignWizard.test.tsx
@@ -2,14 +2,12 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import CampaignWizard from '../components/Campaign/CampaignWizard';
 import { vi, beforeEach } from 'vitest';
 import useCampaignStore from '../stores/useCampaignStore';
-import { createCampaign, createAdSet, createAd } from '../components/mediaQueue';
+import { createCampaign } from '../services/campaign';
 
 defineGlobals();
 
-vi.mock('../components/mediaQueue', () => ({
-  createCampaign: vi.fn(() => Promise.resolve('camp')),
-  createAdSet: vi.fn(() => Promise.resolve('adset')),
-  createAd: vi.fn(() => Promise.resolve('ad')),
+vi.mock('../services/campaign', () => ({
+  createCampaign: vi.fn(() => Promise.resolve()),
 }));
 
 vi.mock('react-toastify', () => ({
@@ -45,13 +43,19 @@ describe('CampaignWizard', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: /Próximo/i }));
 
-    expect(await screen.findByText(/Resumo Final/i)).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: /Finalizar/i }));
+    expect(await screen.findByText(/Revise sua campanha/i)).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole('button', { name: /Confirmar e Criar Campanha/i })
+    );
 
     await waitFor(() => {
-      expect(createCampaign).toHaveBeenCalledWith('Nova Campanha', '');
-      expect(createAdSet).toHaveBeenCalled();
-      expect(createAd).toHaveBeenCalled();
+      expect(createCampaign).toHaveBeenCalledWith({
+        budgetType: 'daily',
+        budgetAmount: 50,
+        startDate: '2023-01-02',
+        endDate: '2023-01-03',
+        audienceId: 'aud-1',
+      });
     });
   });
 });

--- a/src/__tests__/StepPreview.test.tsx
+++ b/src/__tests__/StepPreview.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import StepPreview from '../steps/StepPreview';
+import useCampaignStore from '../stores/useCampaignStore';
+import { vi } from 'vitest';
+import { act } from 'react';
+import * as campaignService from '../services/campaign';
+
+describe('StepPreview', () => {
+  beforeEach(() => {
+    useCampaignStore.getState().resetCampaign();
+  });
+
+  it('shows data and handles actions', async () => {
+    const state = useCampaignStore.getState();
+    act(() => {
+      state.setBudgetType('total');
+      state.setBudgetAmount(100);
+      state.setStartDate('2023-01-01');
+      state.setEndDate('2023-01-02');
+      state.setAudienceId('aud1');
+      state.setStep('preview');
+    });
+
+    const createCampaignSpy = vi
+      .spyOn(campaignService, 'createCampaign')
+      .mockResolvedValue();
+
+    render(<StepPreview />);
+
+    expect(screen.getByText(/Total/)).toBeInTheDocument();
+    expect(screen.getByText(/100/)).toBeInTheDocument();
+    expect(screen.getByText(/2023-01-01/)).toBeInTheDocument();
+    expect(screen.getByText(/2023-01-02/)).toBeInTheDocument();
+    expect(screen.getByText(/aud1/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Voltar/i }));
+    expect(useCampaignStore.getState().stepIndex).toBe(3);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /Confirmar e Criar Campanha/i })
+    );
+
+    await waitFor(() => {
+      expect(createCampaignSpy).toHaveBeenCalledWith({
+        budgetType: 'total',
+        budgetAmount: 100,
+        startDate: '2023-01-01',
+        endDate: '2023-01-02',
+        audienceId: 'aud1',
+      });
+    });
+  });
+});

--- a/src/components/Campaign/CampaignWizard.tsx
+++ b/src/components/Campaign/CampaignWizard.tsx
@@ -4,14 +4,14 @@ import StepInvestment from '../../steps/StepInvestment';
 import StepScheduling from './steps/StepScheduling';
 import StepTargeting from './steps/StepTargeting';
 import StepContent from './steps/StepContent';
-import StepReview from './steps/StepReview';
+import StepPreview from '../../steps/StepPreview';
 
 const steps = [
   StepInvestment,
   StepScheduling,
   StepTargeting,
   StepContent,
-  StepReview,
+  StepPreview,
 ];
 
 const CampaignWizard: React.FC = () => {

--- a/src/services/campaign.ts
+++ b/src/services/campaign.ts
@@ -1,0 +1,12 @@
+export interface CampaignPreview {
+  budgetType: 'daily' | 'total';
+  budgetAmount: number;
+  startDate: string;
+  endDate: string;
+  audienceId: string;
+}
+
+export async function createCampaign(campaign: CampaignPreview): Promise<void> {
+  console.log('Criando campanha', campaign);
+  return Promise.resolve();
+}

--- a/src/steps/StepPreview.tsx
+++ b/src/steps/StepPreview.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import useCampaignStore from '../stores/useCampaignStore';
+import { createCampaign } from '../services/campaign';
+
+const StepPreview: React.FC = () => {
+  const budgetType = useCampaignStore((s) => s.budgetType);
+  const budgetAmount = useCampaignStore((s) => s.budgetAmount);
+  const startDate = useCampaignStore((s) => s.startDate);
+  const endDate = useCampaignStore((s) => s.endDate);
+  const audienceId = useCampaignStore((s) => s.audienceId);
+  const goBack = useCampaignStore((s) => s.goBack);
+
+  const handleConfirm = async () => {
+    const campaign = { budgetType, budgetAmount, startDate, endDate, audienceId };
+    await createCampaign(campaign);
+    console.log(campaign);
+  };
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-lg font-bold">Revise sua campanha</h2>
+      <ul className="space-y-1">
+        <li>Tipo de orçamento: {budgetType === 'daily' ? 'Diário' : 'Total'}</li>
+        <li>Valor do orçamento: {budgetAmount}</li>
+        <li>Data de início: {startDate}</li>
+        <li>Data de término: {endDate}</li>
+        <li>ID de público: {audienceId}</li>
+      </ul>
+      <div className="flex space-x-2">
+        <button
+          onClick={goBack}
+          className="px-4 py-2 rounded bg-gray-500 text-white hover:bg-gray-600"
+        >
+          Voltar
+        </button>
+        <button
+          onClick={handleConfirm}
+          className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700"
+        >
+          Confirmar e Criar Campanha
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default StepPreview;

--- a/src/stores/useCampaignStore.ts
+++ b/src/stores/useCampaignStore.ts
@@ -6,7 +6,7 @@ export const wizardSteps = [
   'scheduling',
   'targeting',
   'content',
-  'review',
+  'preview',
 ] as const;
 export type WizardStep = typeof wizardSteps[number];
 


### PR DESCRIPTION
## Summary
- implement `StepPreview` step to confirm campaign data
- mock campaign service for createCampaign
- update wizard flow to include new preview step
- adjust Zustand store steps
- test new component and wizard flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688279eef0ec832f983d47c029aea58a