### PR TITLE
Finalize wizard flow

### DIFF
--- a/src/__tests__/StepPreview.test.tsx
+++ b/src/__tests__/StepPreview.test.tsx
@@ -23,7 +23,7 @@ describe('StepPreview', () => {
 
     const createCampaignSpy = vi
       .spyOn(campaignService, 'createCampaign')
-      .mockResolvedValue();
+      .mockResolvedValue(true);
 
     render(<StepPreview />);
 
@@ -49,5 +49,14 @@ describe('StepPreview', () => {
         audienceId: 'aud1',
       });
     });
+
+    expect(
+      await screen.findByText(/Campanha criada com sucesso!/i)
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Criar nova campanha/i }));
+
+    expect(useCampaignStore.getState().stepIndex).toBe(0);
+    expect(useCampaignStore.getState().audienceId).toBe('');
   });
 });

--- a/src/services/campaign.ts
+++ b/src/services/campaign.ts
@@ -6,7 +6,9 @@ export interface CampaignPreview {
   audienceId: string;
 }
 
-export async function createCampaign(campaign: CampaignPreview): Promise<void> {
-  console.log('Criando campanha', campaign);
-  return Promise.resolve();
+export async function createCampaign(
+  campaign: CampaignPreview
+): Promise<boolean> {
+  await new Promise(resolve => setTimeout(resolve, 500));
+  return true;
 }

--- a/src/steps/StepPreview.tsx
+++ b/src/steps/StepPreview.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import useCampaignStore from '../stores/useCampaignStore';
 import { createCampaign } from '../services/campaign';
 
@@ -9,11 +9,22 @@ const StepPreview: React.FC = () => {
   const endDate = useCampaignStore((s) => s.endDate);
   const audienceId = useCampaignStore((s) => s.audienceId);
   const goBack = useCampaignStore((s) => s.goBack);
+  const resetCampaign = useCampaignStore((s) => s.resetCampaign);
+  const [created, setCreated] = useState(false);
+  const [loading, setLoading] = useState(false);
 
   const handleConfirm = async () => {
+    setLoading(true);
     const campaign = { budgetType, budgetAmount, startDate, endDate, audienceId };
-    await createCampaign(campaign);
-    console.log(campaign);
+    const success = await createCampaign(campaign);
+    setLoading(false);
+    if (success) {
+      setCreated(true);
+    }
+  };
+
+  const handleNewCampaign = () => {
+    resetCampaign();
   };
 
   return (
@@ -33,13 +44,24 @@ const StepPreview: React.FC = () => {
         >
           Voltar
         </button>
-        <button
-          onClick={handleConfirm}
-          className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700"
-        >
-          Confirmar e Criar Campanha
-        </button>
+        {!created ? (
+          <button
+            onClick={handleConfirm}
+            disabled={loading}
+            className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            Confirmar e Criar Campanha
+          </button>
+        ) : (
+          <button
+            onClick={handleNewCampaign}
+            className="px-4 py-2 rounded bg-green-600 text-white hover:bg-green-700"
+          >
+            Criar nova campanha
+          </button>
+        )}
       </div>
+      {created && <p>Campanha criada com sucesso!</p>}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- simulate final send in campaign service
- implement confirmation workflow in StepPreview
- reset wizard when creating new campaign
- verify new behavior in tests

## Testing
- `npx vitest run --silent`

------
https://chatgpt.com/codex/tasks/task_e_6882821f98e4832fb547ff6c081c7bb7