### PR TITLE
Implement wizard UI improvements and error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ Plataforma de Ads
    ```bash
    npm run build
    ```
+   O diretório `dist/` será gerado com os arquivos estáticos. Para revisar o
+   resultado localmente execute:
+   ```bash
+   npm run preview
+   ```
+   Em provedores como o Vercel defina o comando de build como `npm run build`
+   e sirva o diretório `dist`.
 
 O projeto utiliza o Vite com `index.html` na raiz do repositório como ponto de entrada.
 Os módulos que interagem com a API da Meta foram movidos para `backend-meta/` e

--- a/src/__tests__/CampaignBudget.test.tsx
+++ b/src/__tests__/CampaignBudget.test.tsx
@@ -26,7 +26,7 @@ describe('CampaignBudget', () => {
 
     // --- Ação 1: Mudar valor ---
     await act(async () => {
-      fireEvent.change(screen.getByLabelText(/Valor do orçamento/i), {
+      fireEvent.change(screen.getByLabelText(/Quanto você quer investir\?/i), {
         target: { value: '20' },
       });
     });
@@ -43,7 +43,7 @@ describe('CampaignBudget', () => {
 
     // --- Ação 2.2: Inserir data de término inválida ---
     await act(async () => {
-      fireEvent.change(screen.getByLabelText(/Data de término/i), {
+      fireEvent.change(screen.getByLabelText(/Quando a campanha termina\?/i), {
         target: { value: '2023-01-01' },
       });
     });
@@ -54,7 +54,7 @@ describe('CampaignBudget', () => {
 
     // --- Ação 3: Corrigir data ---
     await act(async () => {
-      fireEvent.change(screen.getByLabelText(/Data de término/i), {
+      fireEvent.change(screen.getByLabelText(/Quando a campanha termina\?/i), {
         target: { value: '2023-01-03' },
       });
     });

--- a/src/__tests__/CampaignWizard.test.tsx
+++ b/src/__tests__/CampaignWizard.test.tsx
@@ -23,13 +23,13 @@ describe('CampaignWizard', () => {
   it('steps through wizard and publishes campaign', async () => {
     render(<CampaignWizard />);
 
-    const amountInput = screen.getByLabelText(/Valor do orçamento/i);
+    const amountInput = screen.getByLabelText(/Quanto você quer investir\?/i);
     fireEvent.change(amountInput, { target: { value: '50' } });
     fireEvent.click(screen.getByRole('button', { name: /Próximo/i }));
 
     const startInput = await screen.findByLabelText(/Data de início/i);
     fireEvent.change(startInput, { target: { value: '2023-01-02' } });
-    fireEvent.change(screen.getByLabelText(/Data de término/i), {
+    fireEvent.change(screen.getByLabelText(/Quando a campanha termina\?/i), {
       target: { value: '2023-01-03' },
     });
     fireEvent.click(screen.getByRole('button', { name: /Próximo/i }));
@@ -55,6 +55,7 @@ describe('CampaignWizard', () => {
         startDate: '2023-01-02',
         endDate: '2023-01-03',
         audienceId: 'aud-1',
+        name: '',
       });
     });
   });

--- a/src/__tests__/StepInvestment.test.tsx
+++ b/src/__tests__/StepInvestment.test.tsx
@@ -18,7 +18,7 @@ describe('StepInvestment', () => {
     expect(screen.getByRole('alert')).toHaveTextContent(/maior que zero/i);
     expect(goNextSpy).not.toHaveBeenCalled();
 
-    fireEvent.change(screen.getByLabelText(/Valor do orçamento/i), {
+    fireEvent.change(screen.getByLabelText(/Quanto você quer investir\?/i), {
       target: { value: '25' },
     });
     fireEvent.click(screen.getByLabelText(/Orçamento total/i));

--- a/src/__tests__/StepPreview.test.tsx
+++ b/src/__tests__/StepPreview.test.tsx
@@ -47,6 +47,7 @@ describe('StepPreview', () => {
         startDate: '2023-01-01',
         endDate: '2023-01-02',
         audienceId: 'aud1',
+        name: '',
       });
     });
 

--- a/src/__tests__/StepScheduling.test.tsx
+++ b/src/__tests__/StepScheduling.test.tsx
@@ -15,7 +15,7 @@ describe('StepScheduling', () => {
     render(<StepScheduling />);
 
     const startInput = screen.getByLabelText(/Data de início/i);
-    const endInput = screen.getByLabelText(/Data de término/i);
+    const endInput = screen.getByLabelText(/Quando a campanha termina\?/i);
 
     fireEvent.change(startInput, { target: { value: '2023-01-02' } });
     fireEvent.change(endInput, { target: { value: '2023-01-01' } });

--- a/src/components/Campaign/CampaignBudget.tsx
+++ b/src/components/Campaign/CampaignBudget.tsx
@@ -56,7 +56,7 @@ const CampaignBudget: React.FC<CampaignBudgetProps> = ({
       </div>
       <div>
         <label className="block mb-1 font-medium" htmlFor="budgetAmount">
-          Valor do orçamento
+          Quanto você quer investir?
         </label>
         <input
           id="budgetAmount"
@@ -83,7 +83,7 @@ const CampaignBudget: React.FC<CampaignBudgetProps> = ({
         </div>
         <div className="flex-1">
           <label className="block mb-1 font-medium" htmlFor="endDate">
-            Data de término
+            Quando a campanha termina?
           </label>
           <input
             id="endDate"

--- a/src/components/Campaign/CampaignWizard.tsx
+++ b/src/components/Campaign/CampaignWizard.tsx
@@ -17,8 +17,10 @@ const steps = [
 const CampaignWizard: React.FC = () => {
   const stepIndex = useCampaignStore((s) => s.stepIndex);
   const Current = steps[stepIndex] ?? StepInvestment;
+  const totalSteps = steps.length;
   return (
     <div className="p-4 border rounded space-y-4">
+      <div className="text-sm text-gray-600">Passo {stepIndex + 1} de {totalSteps}</div>
       <Current />
     </div>
   );

--- a/src/components/Campaign/steps/StepContent.tsx
+++ b/src/components/Campaign/steps/StepContent.tsx
@@ -3,7 +3,9 @@ import useCampaignStore, { CampaignCreativeValues } from '../../../stores/useCam
 
 const StepContent: React.FC = () => {
   const creative = useCampaignStore((s) => s.creative);
+  const name = useCampaignStore((s) => s.name);
   const setCreative = useCampaignStore((s) => s.setCreative);
+  const setName = useCampaignStore((s) => s.setName);
   const goNext = useCampaignStore((s) => s.goNext);
   const goBack = useCampaignStore((s) => s.goBack);
   const stepIndex = useCampaignStore((s) => s.stepIndex);
@@ -20,6 +22,19 @@ const StepContent: React.FC = () => {
   return (
     <div className="space-y-4">
       <h2 className="text-lg font-bold">Mídia e Conteúdo</h2>
+      <div>
+        <label className="block mb-1 font-medium" htmlFor="campaignName">
+          Nome da campanha
+        </label>
+        <input
+          id="campaignName"
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="border rounded px-2 py-1 w-full"
+          aria-label="Nome da campanha"
+        />
+      </div>
       <input type="file" multiple onChange={onFilesChange} />
       <textarea
         value={creative.message}
@@ -30,18 +45,18 @@ const StepContent: React.FC = () => {
       <div className="flex space-x-2">
         {stepIndex > 0 && (
           <button
-            onClick={goBack}
-            className="px-4 py-2 rounded bg-gray-500 text-white hover:bg-gray-600"
-          >
-            Voltar
-          </button>
-        )}
-        <button
-          onClick={goNext}
-          className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700"
+          onClick={goBack}
+          className="px-4 py-2 rounded border bg-gray-100 hover:bg-gray-200"
         >
-          Próximo
+          Voltar
         </button>
+      )}
+      <button
+        onClick={goNext}
+        className="px-4 py-2 rounded border bg-blue-600 text-white hover:bg-blue-700"
+      >
+        Próximo
+      </button>
       </div>
     </div>
   );

--- a/src/components/Campaign/steps/StepScheduling.tsx
+++ b/src/components/Campaign/steps/StepScheduling.tsx
@@ -37,7 +37,7 @@ const StepScheduling: React.FC = () => {
         value={endDate}
         onChange={(e) => setEndDate(e.target.value)}
         className="border rounded px-2 py-1"
-        aria-label="Data de término"
+        aria-label="Quando a campanha termina?"
       />
       {error && (
         <p className="text-red-500" role="alert">
@@ -48,14 +48,14 @@ const StepScheduling: React.FC = () => {
         {stepIndex > 0 && (
           <button
             onClick={goBack}
-            className="px-4 py-2 rounded bg-gray-500 text-white hover:bg-gray-600"
+            className="px-4 py-2 rounded border bg-gray-100 hover:bg-gray-200"
           >
             Voltar
           </button>
         )}
         <button
           onClick={handleNext}
-          className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700"
+          className="px-4 py-2 rounded border bg-blue-600 text-white hover:bg-blue-700"
         >
           Próximo
         </button>

--- a/src/components/Campaign/steps/StepTargeting.tsx
+++ b/src/components/Campaign/steps/StepTargeting.tsx
@@ -22,14 +22,14 @@ const StepTargeting: React.FC = () => {
         {stepIndex > 0 && (
           <button
             onClick={goBack}
-            className="px-4 py-2 rounded bg-gray-500 text-white hover:bg-gray-600"
+            className="px-4 py-2 rounded border bg-gray-100 hover:bg-gray-200"
           >
             Voltar
           </button>
         )}
         <button
           onClick={goNext}
-          className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700"
+          className="px-4 py-2 rounded border bg-blue-600 text-white hover:bg-blue-700"
         >
           Próximo
         </button>

--- a/src/services/campaign.ts
+++ b/src/services/campaign.ts
@@ -4,11 +4,15 @@ export interface CampaignPreview {
   startDate: string;
   endDate: string;
   audienceId: string;
+  name: string;
 }
 
 export async function createCampaign(
   campaign: CampaignPreview
 ): Promise<boolean> {
   await new Promise(resolve => setTimeout(resolve, 500));
+  if (campaign.name === 'erro') {
+    return false;
+  }
   return true;
 }

--- a/src/steps/StepInvestment.tsx
+++ b/src/steps/StepInvestment.tsx
@@ -47,7 +47,7 @@ const StepInvestment: React.FC = () => {
       </div>
       <div>
         <label className="block mb-1 font-medium" htmlFor="budgetAmount">
-          Valor do orçamento
+          Quanto você quer investir?
         </label>
         <input
           id="budgetAmount"
@@ -56,7 +56,7 @@ const StepInvestment: React.FC = () => {
           value={budgetAmount}
           onChange={(e) => setBudgetAmount(Number(e.target.value))}
           className="border rounded px-2 py-1"
-          aria-label="Valor do orçamento"
+          aria-label="Quanto você quer investir?"
         />
       </div>
       {error && (
@@ -68,14 +68,14 @@ const StepInvestment: React.FC = () => {
         {stepIndex > 0 && (
           <button
             onClick={goBack}
-            className="px-4 py-2 rounded bg-gray-500 text-white hover:bg-gray-600"
+            className="px-4 py-2 rounded border bg-gray-100 hover:bg-gray-200"
           >
             Voltar
           </button>
         )}
         <button
           onClick={handleNext}
-          className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700"
+          className="px-4 py-2 rounded border bg-blue-600 text-white hover:bg-blue-700"
         >
           Próximo
         </button>

--- a/src/steps/StepPreview.tsx
+++ b/src/steps/StepPreview.tsx
@@ -8,18 +8,22 @@ const StepPreview: React.FC = () => {
   const startDate = useCampaignStore((s) => s.startDate);
   const endDate = useCampaignStore((s) => s.endDate);
   const audienceId = useCampaignStore((s) => s.audienceId);
+  const name = useCampaignStore((s) => s.name);
   const goBack = useCampaignStore((s) => s.goBack);
   const resetCampaign = useCampaignStore((s) => s.resetCampaign);
   const [created, setCreated] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
 
   const handleConfirm = async () => {
     setLoading(true);
-    const campaign = { budgetType, budgetAmount, startDate, endDate, audienceId };
+    const campaign = { budgetType, budgetAmount, startDate, endDate, audienceId, name };
     const success = await createCampaign(campaign);
     setLoading(false);
     if (success) {
       setCreated(true);
+    } else {
+      setError('Falha ao criar campanha.');
     }
   };
 
@@ -31,8 +35,9 @@ const StepPreview: React.FC = () => {
     <div className="space-y-4">
       <h2 className="text-lg font-bold">Revise sua campanha</h2>
       <ul className="space-y-1">
+        <li>Nome: {name}</li>
         <li>Tipo de orçamento: {budgetType === 'daily' ? 'Diário' : 'Total'}</li>
-        <li>Valor do orçamento: {budgetAmount}</li>
+        <li>Investimento: {budgetAmount}</li>
         <li>Data de início: {startDate}</li>
         <li>Data de término: {endDate}</li>
         <li>ID de público: {audienceId}</li>
@@ -40,7 +45,7 @@ const StepPreview: React.FC = () => {
       <div className="flex space-x-2">
         <button
           onClick={goBack}
-          className="px-4 py-2 rounded bg-gray-500 text-white hover:bg-gray-600"
+          className="px-4 py-2 rounded border bg-gray-100 hover:bg-gray-200"
         >
           Voltar
         </button>
@@ -48,19 +53,20 @@ const StepPreview: React.FC = () => {
           <button
             onClick={handleConfirm}
             disabled={loading}
-            className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
+            className={`px-4 py-2 rounded border text-white ${loading ? 'bg-blue-400' : 'bg-blue-600 hover:bg-blue-700'} disabled:opacity-50`}
           >
-            Confirmar e Criar Campanha
+            {loading ? 'Confirmando...' : 'Confirmar e Criar Campanha'}
           </button>
         ) : (
           <button
             onClick={handleNewCampaign}
-            className="px-4 py-2 rounded bg-green-600 text-white hover:bg-green-700"
+            className="px-4 py-2 rounded border bg-green-600 text-white hover:bg-green-700"
           >
             Criar nova campanha
           </button>
         )}
       </div>
+      {error && <p className="text-red-500" role="alert">{error}</p>}
       {created && <p>Campanha criada com sucesso!</p>}
     </div>
   );

--- a/src/stores/useCampaignStore.ts
+++ b/src/stores/useCampaignStore.ts
@@ -40,6 +40,7 @@ export const initialBudget: CampaignBudgetValues = {
 };
 
 export interface CampaignValues extends CampaignBudgetValues {
+  name: string;
   objective: string;
   audienceId: string;
   creative: CampaignCreativeValues;
@@ -50,6 +51,7 @@ export interface CampaignValues extends CampaignBudgetValues {
 
 export const initialCampaign: CampaignValues = {
   ...initialBudget,
+  name: '',
   objective: '',
   audienceId: '',
   creative: { files: [], message: '', link: '', page: '' },
@@ -72,6 +74,7 @@ export interface CampaignState extends CampaignValues {
   setEndDate: (endDate: string) => void;
   setObjective: (objective: string) => void;
   setAudienceId: (audienceId: string) => void;
+  setName: (name: string) => void;
   setCreative: (creative: CampaignCreativeValues) => void;
   setTargeting: (targeting: CampaignTargeting | null) => void;
   setPlacements: (placements: string[]) => void;
@@ -110,6 +113,7 @@ export const useCampaignStore = create<CampaignState>()(
         setStartDate: startDate => set({ startDate }),
         setEndDate: endDate => set({ endDate }),
         setObjective: objective => set({ objective }),
+        setName: name => set({ name }),
         setAudienceId: audienceId => set({ audienceId }),
         setCreative: creative => set({ creative }),
         setTargeting: targeting => set({ targeting }),
@@ -150,6 +154,7 @@ export const selectStartDate = (state: CampaignState) => state.startDate;
 export const selectEndDate = (state: CampaignState) => state.endDate;
 export const selectObjective = (state: CampaignState) => state.objective;
 export const selectAudienceId = (state: CampaignState) => state.audienceId;
+export const selectName = (state: CampaignState) => state.name;
 export const selectCreative = (state: CampaignState) => state.creative;
 export const selectTargeting = (state: CampaignState) => state.targeting;
 export const selectPlacements = (state: CampaignState) => state.placements;
@@ -168,6 +173,7 @@ export const selectSetStartDate = (state: CampaignState) => state.setStartDate;
 export const selectSetEndDate = (state: CampaignState) => state.setEndDate;
 export const selectSetObjective = (state: CampaignState) => state.setObjective;
 export const selectSetAudienceId = (state: CampaignState) => state.setAudienceId;
+export const selectSetName = (state: CampaignState) => state.setName;
 export const selectSetCreative = (state: CampaignState) => state.setCreative;
 export const selectSetTargeting = (state: CampaignState) => state.setTargeting;
 export const selectSetPlacements = (state: CampaignState) => state.setPlacements;


### PR DESCRIPTION
## Summary
- update wizard buttons styling and progress indicator
- add campaign name handling and error simulation when name is "erro"
- tweak labels for clarity
- document preview build in README
- adjust tests to new labels and API shape

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68828973b890832fb836570008de93d2