### PR TITLE
Improva layout e passos do wizard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,10 @@
     "": {
       "name": "mvp-ads",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "dexie": "^3.2.4",
+        "lucide-react": "^0.525.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.4.0",
@@ -3260,6 +3262,15 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.525.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.525.0.tgz",
+      "integrity": "sha512-Tm1txJ2OkymCGkvwoHt33Y2JpN5xucVq1slHcgE6Lk0WjDfjgKWor5CdVER8U6DvcfMwh4M8XxmpTiyzfmfDYQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "dexie": "^3.2.4",
+    "lucide-react": "^0.525.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.4.0",

--- a/src/__tests__/CampaignWizard.test.tsx
+++ b/src/__tests__/CampaignWizard.test.tsx
@@ -28,17 +28,33 @@ describe('CampaignWizard', () => {
     fireEvent.click(screen.getByRole('button', { name: /Próximo/i }));
 
     const startInput = await screen.findByLabelText(/Data de início/i);
-    fireEvent.change(startInput, { target: { value: '2023-01-02' } });
+    const today = new Date().toISOString().split('T')[0];
+    const tomorrow = new Date(Date.now() + 86400000).toISOString().split('T')[0];
+    fireEvent.change(startInput, { target: { value: today } });
     fireEvent.change(screen.getByLabelText(/Quando a campanha termina\?/i), {
-      target: { value: '2023-01-03' },
+      target: { value: tomorrow },
     });
     fireEvent.click(screen.getByRole('button', { name: /Próximo/i }));
 
-    const audienceInput = await screen.findByLabelText(/Audience ID/i);
-    fireEvent.change(audienceInput, { target: { value: 'aud-1' } });
+    await screen.findByLabelText(/Nome do Público/i);
+    fireEvent.change(screen.getByLabelText(/Nome do Público/i), {
+      target: { value: 'aud-1' },
+    });
+    fireEvent.change(screen.getByLabelText(/Localização/i), {
+      target: { value: 'sp' },
+    });
+    fireEvent.change(screen.getByLabelText(/Interesses/i), {
+      target: { value: 'tech' },
+    });
+    fireEvent.change(screen.getByLabelText(/Idade mínima/i), {
+      target: { value: '18' },
+    });
+    fireEvent.change(screen.getByLabelText(/Idade máxima/i), {
+      target: { value: '30' },
+    });
     fireEvent.click(screen.getByRole('button', { name: /Próximo/i }));
 
-    fireEvent.change(await screen.findByLabelText(/Mensagem/i), {
+    fireEvent.change(await screen.findByLabelText(/Texto principal do anúncio/i), {
       target: { value: 'Hello' },
     });
     fireEvent.click(screen.getByRole('button', { name: /Próximo/i }));
@@ -52,9 +68,16 @@ describe('CampaignWizard', () => {
       expect(createCampaign).toHaveBeenCalledWith({
         budgetType: 'daily',
         budgetAmount: 50,
-        startDate: '2023-01-02',
-        endDate: '2023-01-03',
-        audienceId: 'aud-1',
+        startDate: today,
+        endDate: tomorrow,
+        audience: {
+          name: 'aud-1',
+          location: 'sp',
+          interests: 'tech',
+          ageMin: 18,
+          ageMax: 30,
+          useSaved: false,
+        },
         name: '',
       });
     });

--- a/src/__tests__/StepPreview.test.tsx
+++ b/src/__tests__/StepPreview.test.tsx
@@ -17,7 +17,14 @@ describe('StepPreview', () => {
       state.setBudgetAmount(100);
       state.setStartDate('2023-01-01');
       state.setEndDate('2023-01-02');
-      state.setAudienceId('aud1');
+      state.setAudience({
+        name: 'aud1',
+        location: 'sp',
+        interests: 'tech',
+        ageMin: 18,
+        ageMax: 30,
+        useSaved: false,
+      });
       state.setStep('preview');
     });
 
@@ -33,8 +40,8 @@ describe('StepPreview', () => {
     expect(screen.getByText(/2023-01-02/)).toBeInTheDocument();
     expect(screen.getByText(/aud1/)).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: /Voltar/i }));
-    expect(useCampaignStore.getState().stepIndex).toBe(3);
+    fireEvent.click(screen.getByRole('button', { name: /Editar campanha/i }));
+    expect(useCampaignStore.getState().stepIndex).toBe(0);
 
     fireEvent.click(
       screen.getByRole('button', { name: /Confirmar e Criar Campanha/i })
@@ -46,7 +53,14 @@ describe('StepPreview', () => {
         budgetAmount: 100,
         startDate: '2023-01-01',
         endDate: '2023-01-02',
-        audienceId: 'aud1',
+        audience: {
+          name: 'aud1',
+          location: 'sp',
+          interests: 'tech',
+          ageMin: 18,
+          ageMax: 30,
+          useSaved: false,
+        },
         name: '',
       });
     });

--- a/src/__tests__/StepScheduling.test.tsx
+++ b/src/__tests__/StepScheduling.test.tsx
@@ -17,8 +17,10 @@ describe('StepScheduling', () => {
     const startInput = screen.getByLabelText(/Data de início/i);
     const endInput = screen.getByLabelText(/Quando a campanha termina\?/i);
 
-    fireEvent.change(startInput, { target: { value: '2023-01-02' } });
-    fireEvent.change(endInput, { target: { value: '2023-01-01' } });
+    const today = new Date().toISOString().split('T')[0];
+    const tomorrow = new Date(Date.now() + 86400000).toISOString().split('T')[0];
+    fireEvent.change(startInput, { target: { value: tomorrow } });
+    fireEvent.change(endInput, { target: { value: today } });
     fireEvent.click(screen.getByRole('button', { name: /Próximo/i }));
 
     expect(screen.getByRole('alert')).toHaveTextContent(
@@ -26,13 +28,14 @@ describe('StepScheduling', () => {
     );
     expect(goNextSpy).not.toHaveBeenCalled();
 
-    fireEvent.change(endInput, { target: { value: '2023-01-03' } });
+    const dayAfter = new Date(Date.now() + 2 * 86400000).toISOString().split('T')[0];
+    fireEvent.change(endInput, { target: { value: dayAfter } });
     fireEvent.click(screen.getByRole('button', { name: /Próximo/i }));
 
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
     expect(updateSpy).toHaveBeenLastCalledWith({
-      startDate: '2023-01-02',
-      endDate: '2023-01-03',
+      startDate: tomorrow,
+      endDate: dayAfter,
     });
     expect(goNextSpy).toHaveBeenCalled();
   });

--- a/src/components/Campaign/CampaignWizard.tsx
+++ b/src/components/Campaign/CampaignWizard.tsx
@@ -19,7 +19,7 @@ const CampaignWizard: React.FC = () => {
   const Current = steps[stepIndex] ?? StepInvestment;
   const totalSteps = steps.length;
   return (
-    <div className="p-4 border rounded space-y-4">
+    <div className="p-4 border rounded space-y-4 max-w-[720px] mx-auto">
       <div className="text-sm text-gray-600">Passo {stepIndex + 1} de {totalSteps}</div>
       <Current />
     </div>

--- a/src/components/Campaign/steps/StepContent.tsx
+++ b/src/components/Campaign/steps/StepContent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import useCampaignStore, { CampaignCreativeValues } from '../../../stores/useCampaignStore';
 
 const StepContent: React.FC = () => {
@@ -10,7 +10,10 @@ const StepContent: React.FC = () => {
   const goBack = useCampaignStore((s) => s.goBack);
   const stepIndex = useCampaignStore((s) => s.stepIndex);
 
-  const handleChange = (field: keyof CampaignCreativeValues, value: string | File[]) => {
+  const handleChange = (
+    field: keyof CampaignCreativeValues,
+    value: string | File[],
+  ) => {
     setCreative({ ...creative, [field]: value } as CampaignCreativeValues);
   };
 
@@ -19,9 +22,16 @@ const StepContent: React.FC = () => {
     handleChange('files', files);
   };
 
+  const previewUrl = useMemo(() => {
+    if (creative.files && creative.files.length > 0) {
+      return URL.createObjectURL(creative.files[0]);
+    }
+    return creative.link;
+  }, [creative.files, creative.link]);
+
   return (
-    <div className="space-y-4">
-      <h2 className="text-lg font-bold">Mídia e Conteúdo</h2>
+    <div className="space-y-6 max-w-[720px] mx-auto px-4">
+      <h2 className="text-lg font-bold">Conteúdo</h2>
       <div>
         <label className="block mb-1 font-medium" htmlFor="campaignName">
           Nome da campanha
@@ -35,13 +45,56 @@ const StepContent: React.FC = () => {
           aria-label="Nome da campanha"
         />
       </div>
-      <input type="file" multiple onChange={onFilesChange} />
+      <div className="space-y-4">
+        <label className="block mb-1 font-medium" htmlFor="imageUpload">
+          Imagem do anúncio
+        </label>
+        <input id="imageUpload" type="file" onChange={onFilesChange} />
+        <div>
+          <label className="block mb-1 font-medium" htmlFor="imageUrl">
+            ou informe a URL da imagem
+          </label>
+          <input
+            id="imageUrl"
+            type="text"
+            value={creative.link}
+            onChange={(e) => handleChange('link', e.target.value)}
+            className="border rounded px-2 py-1 w-full"
+          />
+        </div>
+        {previewUrl && (
+          <div className="border rounded p-2 w-full max-w-[320px]">
+            <img
+              src={previewUrl}
+              alt="Pré-visualização"
+              className="object-contain max-h-[320px] mx-auto"
+            />
+          </div>
+        )}
+      </div>
+      <label className="block mb-1 font-medium" htmlFor="message">
+        Texto principal do anúncio
+      </label>
       <textarea
+        id="message"
         value={creative.message}
         onChange={(e) => handleChange('message', e.target.value)}
         className="border rounded px-2 py-1 w-full"
-        aria-label="Mensagem"
+        rows={4}
+        aria-label="Texto principal do anúncio"
       />
+      <div>
+        <label className="block mb-1 font-medium" htmlFor="destination">
+          Link de destino
+        </label>
+        <input
+          id="destination"
+          type="text"
+          value={creative.page}
+          onChange={(e) => handleChange('page', e.target.value)}
+          className="border rounded px-2 py-1 w-full"
+        />
+      </div>
       <div className="flex space-x-2">
         {stepIndex > 0 && (
           <button

--- a/src/components/Campaign/steps/StepScheduling.tsx
+++ b/src/components/Campaign/steps/StepScheduling.tsx
@@ -12,7 +12,17 @@ const StepScheduling: React.FC = () => {
   const stepIndex = useCampaignStore((s) => s.stepIndex);
   const [error, setError] = useState('');
 
+  const today = new Date().toISOString().split('T')[0];
+
   const handleNext = () => {
+    if (startDate && startDate < today) {
+      setError('A data de início não pode ser anterior a hoje.');
+      return;
+    }
+    if (endDate && endDate < today) {
+      setError('A data de término não pode ser anterior a hoje.');
+      return;
+    }
     if (startDate && endDate && endDate < startDate) {
       setError('A data de término não pode ser anterior à data de início.');
       return;
@@ -23,10 +33,11 @@ const StepScheduling: React.FC = () => {
   };
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-6 max-w-[720px] mx-auto px-4">
       <h2 className="text-lg font-bold">Agendamento</h2>
       <input
         type="date"
+        min={today}
         value={startDate}
         onChange={(e) => setStartDate(e.target.value)}
         className="border rounded px-2 py-1"
@@ -34,6 +45,7 @@ const StepScheduling: React.FC = () => {
       />
       <input
         type="date"
+        min={today}
         value={endDate}
         onChange={(e) => setEndDate(e.target.value)}
         className="border rounded px-2 py-1"

--- a/src/components/Campaign/steps/StepTargeting.tsx
+++ b/src/components/Campaign/steps/StepTargeting.tsx
@@ -2,22 +2,89 @@ import React from 'react';
 import useCampaignStore from '../../../stores/useCampaignStore';
 
 const StepTargeting: React.FC = () => {
-  const audienceId = useCampaignStore((s) => s.audienceId);
-  const setAudienceId = useCampaignStore((s) => s.setAudienceId);
+  const audience = useCampaignStore((s) => s.audience);
+  const setAudience = useCampaignStore((s) => s.setAudience);
   const goNext = useCampaignStore((s) => s.goNext);
   const goBack = useCampaignStore((s) => s.goBack);
   const stepIndex = useCampaignStore((s) => s.stepIndex);
 
   return (
-    <div className="space-y-4">
-      <h2 className="text-lg font-bold">Segmentação</h2>
-      <input
-        type="text"
-        value={audienceId}
-        onChange={(e) => setAudienceId(e.target.value)}
-        className="border rounded px-2 py-1"
-        aria-label="Audience ID"
-      />
+    <div className="space-y-6 max-w-[720px] mx-auto px-4">
+      <h2 className="text-lg font-bold">Público</h2>
+      <div className="space-y-4">
+        <div>
+          <label className="block mb-1 font-medium" htmlFor="audienceName">
+            Nome do Público
+          </label>
+          <input
+            id="audienceName"
+            type="text"
+            value={audience.name}
+            onChange={(e) => setAudience({ ...audience, name: e.target.value })}
+            className="border rounded px-2 py-1 w-full"
+          />
+        </div>
+        <div>
+          <label className="block mb-1 font-medium" htmlFor="location">
+            Localização
+          </label>
+          <input
+            id="location"
+            type="text"
+            value={audience.location}
+            onChange={(e) => setAudience({ ...audience, location: e.target.value })}
+            className="border rounded px-2 py-1 w-full"
+          />
+        </div>
+        <div>
+          <label className="block mb-1 font-medium" htmlFor="interests">
+            Interesses
+          </label>
+          <textarea
+            id="interests"
+            value={audience.interests}
+            onChange={(e) => setAudience({ ...audience, interests: e.target.value })}
+            className="border rounded px-2 py-1 w-full"
+            rows={3}
+          />
+        </div>
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className="block mb-1 font-medium" htmlFor="ageMin">
+              Idade mínima
+            </label>
+            <input
+              id="ageMin"
+              type="number"
+              min={0}
+              value={audience.ageMin}
+              onChange={(e) => setAudience({ ...audience, ageMin: Number(e.target.value) })}
+              className="border rounded px-2 py-1 w-full"
+            />
+          </div>
+          <div>
+            <label className="block mb-1 font-medium" htmlFor="ageMax">
+              Idade máxima
+            </label>
+            <input
+              id="ageMax"
+              type="number"
+              min={0}
+              value={audience.ageMax}
+              onChange={(e) => setAudience({ ...audience, ageMax: Number(e.target.value) })}
+              className="border rounded px-2 py-1 w-full"
+            />
+          </div>
+        </div>
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={audience.useSaved}
+            onChange={(e) => setAudience({ ...audience, useSaved: e.target.checked })}
+          />
+          Usar público salvo
+        </label>
+      </div>
       <div className="flex space-x-2">
         {stepIndex > 0 && (
           <button

--- a/src/services/campaign.ts
+++ b/src/services/campaign.ts
@@ -3,7 +3,7 @@ export interface CampaignPreview {
   budgetAmount: number;
   startDate: string;
   endDate: string;
-  audienceId: string;
+  audience: unknown;
   name: string;
 }
 

--- a/src/steps/StepInvestment.tsx
+++ b/src/steps/StepInvestment.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Info } from 'lucide-react';
 import useCampaignStore from '../stores/useCampaignStore';
 
 const StepInvestment: React.FC = () => {
@@ -23,41 +24,63 @@ const StepInvestment: React.FC = () => {
   };
 
   return (
-    <div className="space-y-4">
-      <h2 className="text-lg font-bold">Orçamento</h2>
-      <div className="flex space-x-4">
-        <label className="flex items-center space-x-1">
-          <input
-            type="radio"
-            value="daily"
-            checked={budgetType === 'daily'}
-            onChange={(e) => setBudgetType(e.target.value as 'daily')}
-          />
-          <span>Orçamento diário</span>
-        </label>
-        <label className="flex items-center space-x-1">
-          <input
-            type="radio"
-            value="total"
-            checked={budgetType === 'total'}
-            onChange={(e) => setBudgetType(e.target.value as 'total')}
-          />
-          <span>Orçamento total</span>
-        </label>
-      </div>
-      <div>
-        <label className="block mb-1 font-medium" htmlFor="budgetAmount">
-          Quanto você quer investir?
-        </label>
-        <input
-          id="budgetAmount"
-          type="number"
-          min={1}
-          value={budgetAmount}
-          onChange={(e) => setBudgetAmount(Number(e.target.value))}
-          className="border rounded px-2 py-1"
-          aria-label="Quanto você quer investir?"
-        />
+    <div className="space-y-6 max-w-[720px] mx-auto px-4">
+      <h2 className="text-lg font-bold flex items-center gap-1">
+        Investimento <Info size={16} className="text-gray-500" />
+      </h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <fieldset className="space-y-2">
+          <legend className="font-medium">Tipo de orçamento</legend>
+          <label className="flex items-center gap-2">
+            <input
+              type="radio"
+              value="daily"
+              checked={budgetType === 'daily'}
+              onChange={(e) => setBudgetType(e.target.value as 'daily')}
+            />
+            <span className="flex items-center gap-1">
+              Orçamento diário
+              <Info
+                size={14}
+                className="text-gray-500"
+                title="Diário: valor gasto por dia."
+              />
+            </span>
+          </label>
+          <label className="flex items-center gap-2">
+            <input
+              type="radio"
+              value="total"
+              checked={budgetType === 'total'}
+              onChange={(e) => setBudgetType(e.target.value as 'total')}
+            />
+            <span className="flex items-center gap-1">
+              Orçamento total
+              <Info
+                size={14}
+                className="text-gray-500"
+                title="Total: valor total da campanha até o final."
+              />
+            </span>
+          </label>
+        </fieldset>
+        <div>
+          <label className="block mb-1 font-medium" htmlFor="budgetAmount">
+            Quanto você quer investir?
+          </label>
+          <div className="relative">
+            <span className="absolute left-2 top-1/2 -translate-y-1/2 text-gray-500">R$</span>
+            <input
+              id="budgetAmount"
+              type="number"
+              min={1}
+              value={budgetAmount}
+              onChange={(e) => setBudgetAmount(Number(e.target.value))}
+              className="border rounded px-2 py-1 pl-7 w-full"
+              aria-label="Quanto você quer investir?"
+            />
+          </div>
+        </div>
       </div>
       {error && (
         <p className="text-red-500" role="alert">

--- a/src/steps/StepPreview.tsx
+++ b/src/steps/StepPreview.tsx
@@ -7,9 +7,10 @@ const StepPreview: React.FC = () => {
   const budgetAmount = useCampaignStore((s) => s.budgetAmount);
   const startDate = useCampaignStore((s) => s.startDate);
   const endDate = useCampaignStore((s) => s.endDate);
-  const audienceId = useCampaignStore((s) => s.audienceId);
+  const audience = useCampaignStore((s) => s.audience);
   const name = useCampaignStore((s) => s.name);
   const goBack = useCampaignStore((s) => s.goBack);
+  const setStep = useCampaignStore((s) => s.setStep);
   const resetCampaign = useCampaignStore((s) => s.resetCampaign);
   const [created, setCreated] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -17,8 +18,8 @@ const StepPreview: React.FC = () => {
 
   const handleConfirm = async () => {
     setLoading(true);
-    const campaign = { budgetType, budgetAmount, startDate, endDate, audienceId, name };
-    const success = await createCampaign(campaign);
+    const campaign = { budgetType, budgetAmount, startDate, endDate, audience, name };
+    const success = await createCampaign(campaign as any);
     setLoading(false);
     if (success) {
       setCreated(true);
@@ -32,22 +33,40 @@ const StepPreview: React.FC = () => {
   };
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-6 max-w-[720px] mx-auto px-4">
       <h2 className="text-lg font-bold">Revise sua campanha</h2>
-      <ul className="space-y-1">
-        <li>Nome: {name}</li>
-        <li>Tipo de orçamento: {budgetType === 'daily' ? 'Diário' : 'Total'}</li>
-        <li>Investimento: {budgetAmount}</li>
-        <li>Data de início: {startDate}</li>
-        <li>Data de término: {endDate}</li>
-        <li>ID de público: {audienceId}</li>
-      </ul>
+      <div className="space-y-4">
+        <div className="border rounded p-4">
+          <h3 className="font-semibold mb-2">Investimento</h3>
+          <p>Tipo: {budgetType === 'daily' ? 'Diário' : 'Total'}</p>
+          <p>Valor: R$ {budgetAmount}</p>
+        </div>
+        <div className="border rounded p-4">
+          <h3 className="font-semibold mb-2">Público</h3>
+          <p>Nome: {audience.name}</p>
+          <p>Localização: {audience.location}</p>
+          <p>Interesses: {audience.interests}</p>
+          <p>
+            Idade: {audience.ageMin} - {audience.ageMax}
+          </p>
+          <p>Usar salvo: {audience.useSaved ? 'Sim' : 'Não'}</p>
+        </div>
+        <div className="border rounded p-4">
+          <h3 className="font-semibold mb-2">Datas</h3>
+          <p>Início: {startDate}</p>
+          <p>Término: {endDate}</p>
+        </div>
+        <div className="border rounded p-4">
+          <h3 className="font-semibold mb-2">Conteúdo</h3>
+          <p>{name}</p>
+        </div>
+      </div>
       <div className="flex space-x-2">
         <button
-          onClick={goBack}
+          onClick={() => setStep('budget')}
           className="px-4 py-2 rounded border bg-gray-100 hover:bg-gray-200"
         >
-          Voltar
+          Editar campanha
         </button>
         {!created ? (
           <button

--- a/src/stores/useCampaignStore.ts
+++ b/src/stores/useCampaignStore.ts
@@ -19,6 +19,15 @@ export interface CampaignCreativeValues {
   page: string;
 }
 
+export interface AudienceValues {
+  name: string;
+  location: string;
+  interests: string;
+  ageMin: number;
+  ageMax: number;
+  useSaved: boolean;
+}
+
 export interface CampaignTargeting {
   [key: string]: unknown;
 }
@@ -43,6 +52,7 @@ export interface CampaignValues extends CampaignBudgetValues {
   name: string;
   objective: string;
   audienceId: string;
+  audience: AudienceValues;
   creative: CampaignCreativeValues;
   targeting: CampaignTargeting | null;
   placements: string[];
@@ -54,6 +64,14 @@ export const initialCampaign: CampaignValues = {
   name: '',
   objective: '',
   audienceId: '',
+  audience: {
+    name: '',
+    location: '',
+    interests: '',
+    ageMin: 18,
+    ageMax: 65,
+    useSaved: false,
+  },
   creative: { files: [], message: '', link: '', page: '' },
   targeting: null,
   placements: [],
@@ -74,6 +92,7 @@ export interface CampaignState extends CampaignValues {
   setEndDate: (endDate: string) => void;
   setObjective: (objective: string) => void;
   setAudienceId: (audienceId: string) => void;
+  setAudience: (audience: AudienceValues) => void;
   setName: (name: string) => void;
   setCreative: (creative: CampaignCreativeValues) => void;
   setTargeting: (targeting: CampaignTargeting | null) => void;
@@ -115,6 +134,7 @@ export const useCampaignStore = create<CampaignState>()(
         setObjective: objective => set({ objective }),
         setName: name => set({ name }),
         setAudienceId: audienceId => set({ audienceId }),
+        setAudience: audience => set({ audience }),
         setCreative: creative => set({ creative }),
         setTargeting: targeting => set({ targeting }),
         setPlacements: placements => set({ placements }),
@@ -154,6 +174,7 @@ export const selectStartDate = (state: CampaignState) => state.startDate;
 export const selectEndDate = (state: CampaignState) => state.endDate;
 export const selectObjective = (state: CampaignState) => state.objective;
 export const selectAudienceId = (state: CampaignState) => state.audienceId;
+export const selectAudience = (state: CampaignState) => state.audience;
 export const selectName = (state: CampaignState) => state.name;
 export const selectCreative = (state: CampaignState) => state.creative;
 export const selectTargeting = (state: CampaignState) => state.targeting;
@@ -173,6 +194,7 @@ export const selectSetStartDate = (state: CampaignState) => state.setStartDate;
 export const selectSetEndDate = (state: CampaignState) => state.setEndDate;
 export const selectSetObjective = (state: CampaignState) => state.setObjective;
 export const selectSetAudienceId = (state: CampaignState) => state.setAudienceId;
+export const selectSetAudience = (state: CampaignState) => state.setAudience;
 export const selectSetName = (state: CampaignState) => state.setName;
 export const selectSetCreative = (state: CampaignState) => state.setCreative;
 export const selectSetTargeting = (state: CampaignState) => state.setTargeting;


### PR DESCRIPTION
## Summary
- add `lucide-react` dependency
- update investment step with budget type tooltip and currency prefix
- validate scheduling with date min and layout tweaks
- expand audience step fields
- enhance content step with image preview and new labels
- summarize info in preview step and allow editing from start
- adjust Zustand store to hold `audience` object
- update tests for new UI

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6882d46edecc832faa53d56fa93b68dd