### PR TITLE
Add campaign objective and placements steps

### DIFF
--- a/src/__tests__/CampaignStore.persist.test.ts
+++ b/src/__tests__/CampaignStore.persist.test.ts
@@ -8,21 +8,21 @@ beforeEach(() => {
 describe('useCampaignStore persistence', () => {
   it('restores state from localStorage on reload', async () => {
     const { default: useCampaignStore } = await import('../stores/useCampaignStore');
-    useCampaignStore.getState().setStep('budget');
+    useCampaignStore.getState().setStep('objective');
 
     const stored = localStorage.getItem('campaign-store');
     expect(stored).not.toBeNull();
 
     vi.resetModules();
     const { default: useCampaignStoreReloaded } = await import('../stores/useCampaignStore');
-    expect(useCampaignStoreReloaded.getState().step).toBe('budget');
+    expect(useCampaignStoreReloaded.getState().step).toBe('objective');
   });
 
   it('resetCampaign clears memory and storage', async () => {
     const { default: useCampaignStore } = await import('../stores/useCampaignStore');
     useCampaignStore.getState().setStep('content');
     useCampaignStore.getState().resetCampaign();
-    expect(useCampaignStore.getState().step).toBe('budget');
+    expect(useCampaignStore.getState().step).toBe('objective');
     expect(localStorage.getItem('campaign-store')).toBeNull();
   });
 });

--- a/src/__tests__/CampaignWizard.test.tsx
+++ b/src/__tests__/CampaignWizard.test.tsx
@@ -23,7 +23,11 @@ describe('CampaignWizard', () => {
   it('steps through wizard and publishes campaign', async () => {
     render(<CampaignWizard />);
 
-    const amountInput = screen.getByLabelText(/Quanto você quer investir\?/i);
+    const objectiveOption = screen.getByLabelText(/Cliques no Link/i);
+    fireEvent.click(objectiveOption);
+    fireEvent.click(screen.getByRole('button', { name: /Próximo/i }));
+
+    const amountInput = await screen.findByLabelText(/Quanto você quer investir\?/i);
     fireEvent.change(amountInput, { target: { value: '50' } });
     fireEvent.click(screen.getByRole('button', { name: /Próximo/i }));
 
@@ -54,6 +58,10 @@ describe('CampaignWizard', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: /Próximo/i }));
 
+    await screen.findByText(/Posicionamentos/);
+    fireEvent.click(screen.getByLabelText(/Feed/));
+    fireEvent.click(screen.getByRole('button', { name: /Próximo/i }));
+
     fireEvent.change(await screen.findByLabelText(/Texto principal do anúncio/i), {
       target: { value: 'Hello' },
     });
@@ -78,6 +86,8 @@ describe('CampaignWizard', () => {
           ageMax: 30,
           useSaved: false,
         },
+        objective: 'LINK_CLICKS',
+        placements: ['Feed'],
         name: '',
       });
     });

--- a/src/__tests__/StepPreview.test.tsx
+++ b/src/__tests__/StepPreview.test.tsx
@@ -17,6 +17,8 @@ describe('StepPreview', () => {
       state.setBudgetAmount(100);
       state.setStartDate('2023-01-01');
       state.setEndDate('2023-01-02');
+      state.setObjective('LINK_CLICKS');
+      state.setPlacements(['Feed']);
       state.setAudience({
         name: 'aud1',
         location: 'sp',
@@ -61,6 +63,8 @@ describe('StepPreview', () => {
           ageMax: 30,
           useSaved: false,
         },
+        objective: 'LINK_CLICKS',
+        placements: ['Feed'],
         name: '',
       });
     });

--- a/src/components/Campaign/CampaignWizard.tsx
+++ b/src/components/Campaign/CampaignWizard.tsx
@@ -1,15 +1,19 @@
 import React from 'react';
 import useCampaignStore from '../../stores/useCampaignStore';
+import StepObjective from './steps/StepObjective';
 import StepInvestment from '../../steps/StepInvestment';
 import StepScheduling from './steps/StepScheduling';
 import StepTargeting from './steps/StepTargeting';
+import StepPlacements from './steps/StepPlacements';
 import StepContent from './steps/StepContent';
 import StepPreview from '../../steps/StepPreview';
 
 const steps = [
+  StepObjective,
   StepInvestment,
   StepScheduling,
   StepTargeting,
+  StepPlacements,
   StepContent,
   StepPreview,
 ];

--- a/src/components/Campaign/steps/StepObjective.tsx
+++ b/src/components/Campaign/steps/StepObjective.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import useCampaignStore from '../../../stores/useCampaignStore';
+
+const options = [
+  { value: 'LINK_CLICKS', label: 'Cliques no Link' },
+  { value: 'CONVERSIONS', label: 'Conversões' },
+];
+
+const StepObjective: React.FC = () => {
+  const objective = useCampaignStore((s) => s.objective);
+  const setObjective = useCampaignStore((s) => s.setObjective);
+  const goNext = useCampaignStore((s) => s.goNext);
+  const goBack = useCampaignStore((s) => s.goBack);
+  const stepIndex = useCampaignStore((s) => s.stepIndex);
+
+  return (
+    <div className="space-y-6 max-w-[720px] mx-auto px-4">
+      <h2 className="text-lg font-bold">Objetivo</h2>
+      <div className="flex space-x-4">
+        {options.map((opt) => (
+          <label key={opt.value} className="flex items-center gap-2">
+            <input
+              type="radio"
+              value={opt.value}
+              checked={objective === opt.value}
+              onChange={(e) => setObjective(e.target.value)}
+            />
+            <span>{opt.label}</span>
+          </label>
+        ))}
+      </div>
+      <div className="flex space-x-2">
+        {stepIndex > 0 && (
+          <button
+            onClick={goBack}
+            className="px-4 py-2 rounded border bg-gray-100 hover:bg-gray-200"
+          >
+            Voltar
+          </button>
+        )}
+        <button
+          onClick={goNext}
+          className="px-4 py-2 rounded border bg-blue-600 text-white hover:bg-blue-700"
+        >
+          Próximo
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default StepObjective;

--- a/src/components/Campaign/steps/StepPlacements.tsx
+++ b/src/components/Campaign/steps/StepPlacements.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import useCampaignStore from '../../../stores/useCampaignStore';
+
+const placementOptions = [
+  'Feed',
+  'Stories',
+  'Marketplace',
+  'Search',
+];
+
+const StepPlacements: React.FC = () => {
+  const placements = useCampaignStore((s) => s.placements);
+  const setPlacements = useCampaignStore((s) => s.setPlacements);
+  const goNext = useCampaignStore((s) => s.goNext);
+  const goBack = useCampaignStore((s) => s.goBack);
+  const stepIndex = useCampaignStore((s) => s.stepIndex);
+
+  const togglePlacement = (p: string) => {
+    const next = placements.includes(p)
+      ? placements.filter((pl) => pl !== p)
+      : [...placements, p];
+    setPlacements(next);
+  };
+
+  return (
+    <div className="space-y-6 max-w-[720px] mx-auto px-4">
+      <h2 className="text-lg font-bold">Posicionamentos</h2>
+      <div className="grid grid-cols-2 gap-2">
+        {placementOptions.map((p) => (
+          <label key={p} className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={placements.includes(p)}
+              onChange={() => togglePlacement(p)}
+            />
+            <span>{p}</span>
+          </label>
+        ))}
+      </div>
+      <div className="flex space-x-2">
+        {stepIndex > 0 && (
+          <button
+            onClick={goBack}
+            className="px-4 py-2 rounded border bg-gray-100 hover:bg-gray-200"
+          >
+            Voltar
+          </button>
+        )}
+        <button
+          onClick={goNext}
+          className="px-4 py-2 rounded border bg-blue-600 text-white hover:bg-blue-700"
+        >
+          Próximo
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default StepPlacements;

--- a/src/steps/StepPreview.tsx
+++ b/src/steps/StepPreview.tsx
@@ -8,6 +8,8 @@ const StepPreview: React.FC = () => {
   const startDate = useCampaignStore((s) => s.startDate);
   const endDate = useCampaignStore((s) => s.endDate);
   const audience = useCampaignStore((s) => s.audience);
+  const objective = useCampaignStore((s) => s.objective);
+  const placements = useCampaignStore((s) => s.placements);
   const name = useCampaignStore((s) => s.name);
   const goBack = useCampaignStore((s) => s.goBack);
   const setStep = useCampaignStore((s) => s.setStep);
@@ -18,7 +20,16 @@ const StepPreview: React.FC = () => {
 
   const handleConfirm = async () => {
     setLoading(true);
-    const campaign = { budgetType, budgetAmount, startDate, endDate, audience, name };
+    const campaign = {
+      budgetType,
+      budgetAmount,
+      startDate,
+      endDate,
+      audience,
+      objective,
+      placements,
+      name,
+    };
     const success = await createCampaign(campaign as any);
     setLoading(false);
     if (success) {
@@ -36,6 +47,10 @@ const StepPreview: React.FC = () => {
     <div className="space-y-6 max-w-[720px] mx-auto px-4">
       <h2 className="text-lg font-bold">Revise sua campanha</h2>
       <div className="space-y-4">
+        <div className="border rounded p-4">
+          <h3 className="font-semibold mb-2">Objetivo</h3>
+          <p>{objective}</p>
+        </div>
         <div className="border rounded p-4">
           <h3 className="font-semibold mb-2">Investimento</h3>
           <p>Tipo: {budgetType === 'daily' ? 'Diário' : 'Total'}</p>
@@ -57,13 +72,17 @@ const StepPreview: React.FC = () => {
           <p>Término: {endDate}</p>
         </div>
         <div className="border rounded p-4">
+          <h3 className="font-semibold mb-2">Posicionamentos</h3>
+          <p>{placements.join(', ')}</p>
+        </div>
+        <div className="border rounded p-4">
           <h3 className="font-semibold mb-2">Conteúdo</h3>
           <p>{name}</p>
         </div>
       </div>
       <div className="flex space-x-2">
         <button
-          onClick={() => setStep('budget')}
+          onClick={() => setStep('objective')}
           className="px-4 py-2 rounded border bg-gray-100 hover:bg-gray-200"
         >
           Editar campanha

--- a/src/stores/useCampaignStore.ts
+++ b/src/stores/useCampaignStore.ts
@@ -2,9 +2,11 @@ import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 
 export const wizardSteps = [
+  'objective',
   'budget',
   'scheduling',
   'targeting',
+  'placements',
   'content',
   'preview',
 ] as const;
@@ -39,7 +41,7 @@ export interface CampaignBudgetValues {
   endDate: string;
 }
 
-export const initialStep: WizardStep = 'budget';
+export const initialStep: WizardStep = 'objective';
 
 export const initialBudget: CampaignBudgetValues = {
   budgetType: 'daily',


### PR DESCRIPTION
## Summary
- add Objective and Placements steps for campaign wizard
- include objective and placements in store and preview
- update tests for new steps

## Testing
- `npm test` *(fails: `Erro no upload de img.png: Error: Upload failed`)*

------
https://chatgpt.com/codex/tasks/task_e_6882d90c2368832fb24e18ca35d71826